### PR TITLE
Feature/71 - Distance nodes in graph

### DIFF
--- a/src/components/GraphViewer/GraphViewer.js
+++ b/src/components/GraphViewer/GraphViewer.js
@@ -145,7 +145,6 @@ const GraphViewer = (props) => {
         ctx.fillStyle = GRAPH_COLORS.textColor;
       }
       ctx.fillText(...textProps);
-      // node.fy = 100 * node.level;
     },
     [hoverNode]
   );
@@ -163,7 +162,6 @@ const GraphViewer = (props) => {
         // Links properties
         linkColor={GRAPH_COLORS.link}
         linkWidth={2}
-        linkCurvature={(link) => (link.target.x < link.source.x ? -0.05 : 0.05)}
         // Allows updating link properties, as color and curvature. Without this, linkCurvature doesn't work.
         linkCanvasObjectMode={'replace'}
         onNodeClick={(node, event) => handleNodeLeftClick(node, event)}

--- a/src/components/GraphViewer/GraphViewer.js
+++ b/src/components/GraphViewer/GraphViewer.js
@@ -36,9 +36,17 @@ const roundRect = (ctx, x, y, width, height, radius, color, alpha) => {
 const GraphViewer = (props) => {
   const graphRef = React.useRef(null);
 
-  const handleNodeClick = (node, event) => {
-    // graphRef.current.ggv.current.centerAt(node.x, node.y, ONE_SECOND);
-    // graphRef.current.ggv.current.zoom(2, ONE_SECOND);
+  const handleNodeLeftClick = (node, event) => {
+  };
+
+  /**
+   * Zoom to node when doing a right click on it
+   * @param {*} node 
+   * @param {*} event 
+   */
+  const handleNodeRightClick = (node, event) => {
+    graphRef.current.ggv.current.centerAt(node.x, node.y, ONE_SECOND);
+    graphRef.current.ggv.current.zoom(2, ONE_SECOND);
   };
 
   const zoomIn = (event) => {
@@ -137,7 +145,7 @@ const GraphViewer = (props) => {
         ctx.fillStyle = GRAPH_COLORS.textColor;
       }
       ctx.fillText(...textProps);
-      node.fy = 100 * node.level;
+      // node.fy = 100 * node.level;
     },
     [hoverNode]
   );
@@ -155,16 +163,17 @@ const GraphViewer = (props) => {
         // Links properties
         linkColor={GRAPH_COLORS.link}
         linkWidth={2}
-        linkCurvature={(link) => (link.target.x < link.source.x ? -0.1 : 0.1)}
+        linkCurvature={(link) => (link.target.x < link.source.x ? -0.05 : 0.05)}
         // Allows updating link properties, as color and curvature. Without this, linkCurvature doesn't work.
         linkCanvasObjectMode={'replace'}
-        onNodeClick={(node, event) => handleNodeClick(node, event)}
+        onNodeClick={(node, event) => handleNodeLeftClick(node, event)}
+        onNodeRightClick={(node, event) => handleNodeRightClick(node, event)}
         onNodeHover={handleNodeHover}
         // Override drawing of canvas objects, draw an image as a node
         nodeCanvasObject={paintNode}
         // td = Top Down, creates Graph with root at top
-        dagMode='null'
-        dagLevelDistance={600}
+        dagMode='radialout'
+        dagLevelDistance={200}
         // Handles error on graph
         onDagError={(loopNodeIds) => {}}
         // Disable dragging of nodes


### PR DESCRIPTION
@ddelpiano @zsinnema 
To distance the nodes, I have been playing with different layouts and a 'radial' layout is working better than a 'tree' layout. Some datasets have lots of folders and files, which are making the lower levels very crowded in a 'tree' layout. Using a 'radial' layout we have a better space graph without doing arranging of the node's X positions, which is something we would have to do with a 'tree' layout. Before we invest time on distancing the nodes on the 'tree' layout graph, we should check if 'radial' is an acceptable layout instead, it came up before as a request in one of the sprint meetings and it might be okay to use it.

**Radial Layout**
![image](https://user-images.githubusercontent.com/4562825/129284466-1628a52c-11a9-4048-86b1-c84fdccd2bc7.png)

**Tree Layout**
![image](https://user-images.githubusercontent.com/4562825/129285406-fc28f806-71a5-4fed-8676-87784a9887ec.png)
