### PR TITLE
#247 - Increase file size allowed on file upload, save debug more on local storage

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -28,7 +28,7 @@ const App = () => {
   const enableUpload = debugFlag !== null ?
     debugFlag === 'true' :
     config.enableUploadDialog === true;
-  const debug = enableUpload === 'true';
+  const debug = enableUpload === true;
 
   const dispatch = useDispatch();
   const [openDatasetsListDialog, setOpenDatasetsListDialog] = useState(false);

--- a/src/components/DatasetsListViewer/DatasetsListDialog.js
+++ b/src/components/DatasetsListViewer/DatasetsListDialog.js
@@ -218,12 +218,12 @@ const DatasetsListDialog = (props) => {
           const versionID = await fetchHeaders(config.repository_url + config.available_datasets);
           const storage = JSON.parse(localStorage.getItem(config.datasetsStorage));
           const storageVersion = storage?.version;
-          const debugStored = storage?.debug;
   
-          if (storage && versionID === storageVersion && debug === debugStored) {
+          if (storage && versionID === storageVersion) {
             dispatch(setDatasetsList(storage.datasets));
+            let filteredDatasets = storage.datasets
             if (!debug) {
-              datasets = storage.datasets.filter(
+              filteredDatasets = storage.datasets.filter(
                 node => node?.attributes?.statusOnPlatform?.[0]?.includes(PUBLISHED)
               );
             }

--- a/src/components/DatasetsListViewer/DatasetsListDialog.js
+++ b/src/components/DatasetsListViewer/DatasetsListDialog.js
@@ -174,7 +174,8 @@ const DatasetsListDialog = (props) => {
       });
       datasetStorage = {
         version : versionID,
-        datasets : parsedDatasets
+        datasets : parsedDatasets,
+        debug : debug
       }
   
       localStorage.setItem(config.datasetsStorage, JSON.stringify(datasetStorage));
@@ -217,9 +218,15 @@ const DatasetsListDialog = (props) => {
           const versionID = await fetchHeaders(config.repository_url + config.available_datasets);
           const storage = JSON.parse(localStorage.getItem(config.datasetsStorage));
           const storageVersion = storage?.version;
+          const debugStored = storage?.debug;
   
-          if (storage && versionID === storageVersion) {
+          if (storage && versionID === storageVersion && debug === debugStored) {
             dispatch(setDatasetsList(storage.datasets));
+            if (!debug) {
+              datasets = storage.datasets.filter(
+                node => node?.attributes?.statusOnPlatform?.[0]?.includes(PUBLISHED)
+              );
+            }
             setFilteredDatasets(storage.datasets);
           } else {
             await loadDatasets(versionID);

--- a/src/constants.js
+++ b/src/constants.js
@@ -4,7 +4,7 @@ export const LIST_DATASETS = 'List Datasets';
 export const SPARC_DATASETS = 'SPARC Datasets';
 export const FILE_UPLOAD_PARAMS = {
   acceptedFileExtensions: ['json', 'ttl'],
-  maxFileSize: 10242880,
+  maxFileSize: 20242880,
   maxFiles: 6,
 };
 export const NODES = ["dataset", "nifti", "volume", "matlab"];


### PR DESCRIPTION
This pull request introduces changes to enhance the handling of debug mode and dataset filtering, as well as updates a file upload parameter. The most significant changes include fixing the debug flag comparison logic, adding debug mode persistence in local storage, and filtering datasets based on their publication status when debug mode is disabled.

### Debug mode improvements:

* [`src/App.js`](diffhunk://#diff-3d74dddefb6e35fbffe3c76ec0712d5c416352d9449e2fcc8210a9dee57dff67L31-R31): Fixed the debug flag comparison logic by ensuring it checks for a boolean value (`true`) rather than a string (`'true'`).
* [`src/components/DatasetsListViewer/DatasetsListDialog.js`](diffhunk://#diff-1255e6960df30f963c8de4a2eb1689d35f57d633c581e9f9f61afae9327518f1L177-R178): Added a `debug` property to the dataset storage object to persist debug mode across sessions.
* [`src/components/DatasetsListViewer/DatasetsListDialog.js`](diffhunk://#diff-1255e6960df30f963c8de4a2eb1689d35f57d633c581e9f9f61afae9327518f1R221-R229): Enhanced dataset filtering logic to exclude unpublished datasets when debug mode is disabled. This ensures only published datasets are displayed to non-debug users.

### File upload parameter update:

* [`src/constants.js`](diffhunk://#diff-8e3b187293d8e7902d08eff3c650466860fe527b0c7da8ec32c1ee4a450f97c5L7-R7): Increased the maximum file size for uploads from 10 MB (`10242880` bytes) to 20 MB (`20242880` bytes).