### PR TITLE
Fix Splinter deduplication of folder nodes

### DIFF
--- a/src/utils/GraphViewerHelper.js
+++ b/src/utils/GraphViewerHelper.js
@@ -187,7 +187,7 @@ const dendrogram = (data) => {
     .separation(function(a,b){
       const aIsLeaf = !a.children || a.children.length === 0;
       const bIsLeaf = !b.children || b.children.length === 0;
-      const base = 15;
+      const base = 30;
       const extra = (aIsLeaf && bIsLeaf) ? base : base * 2;
       return 1 + extra;
     });
@@ -288,14 +288,14 @@ export const getPrunedTree = (graph_id, layout) => {
     visibleNodes.forEach( n => {
       if ( layout === TOP_DOWN.layout ) {
         if ( mapNodes[n.id] ) {
-          n.xPos = mapNodes[n.id].x * nodeSpace
+          n.xPos = mapNodes[n.id].x
           n.fx = n.xPos;
           n.fy = 50 * n.level;
         }
       }
       if ( layout === LEFT_RIGHT.layout ) {
         if ( mapNodes[n.id] ) {
-          n.yPos = mapNodes[n.id].x * nodeSpace
+          n.yPos = mapNodes[n.id].x
           n.fy = n.yPos;
           n.fx = 50 * n.level;
         }

--- a/src/utils/GraphViewerHelper.js
+++ b/src/utils/GraphViewerHelper.js
@@ -286,14 +286,14 @@ export const getPrunedTree = (graph_id, layout) => {
     visibleNodes.forEach( n => {
       if ( layout === TOP_DOWN.layout ) {
         if ( mapNodes[n.id] ) {
-          n.xPos = mapNodes[n.id].x
+          n.xPos = mapNodes[n.id].x * nodeSpace
           n.fx = n.xPos;
           n.fy = 50 * n.level;
         }
       }
       if ( layout === LEFT_RIGHT.layout ) {
         if ( mapNodes[n.id] ) {
-          n.yPos = mapNodes[n.id].x
+          n.yPos = mapNodes[n.id].x * nodeSpace
           n.fy = n.yPos;
           n.fx = 50 * n.level;
         }

--- a/src/utils/GraphViewerHelper.js
+++ b/src/utils/GraphViewerHelper.js
@@ -185,9 +185,11 @@ const hierarchy = (data) =>{
 const dendrogram = (data) => {
     const dendrogramGenerator = d3.cluster().nodeSize([1, 100])
     .separation(function(a,b){
-      return 1 + d3.sum([a,b].map(function(d){
-        return 15
-      }))
+      const aIsLeaf = !a.children || a.children.length === 0;
+      const bIsLeaf = !b.children || b.children.length === 0;
+      const base = 15;
+      const extra = (aIsLeaf && bIsLeaf) ? base : base * 2;
+      return 1 + extra;
     });
     return dendrogramGenerator(hierarchy(data));
 }

--- a/src/utils/Splinter.js
+++ b/src/utils/Splinter.js
@@ -1095,7 +1095,25 @@ class Splinter {
             }
         }
         const new_node = this.buildNodeFromJson(node, level);
-        if (!new_node || !parent) {
+        if (!parent) {
+            return;
+        }
+        if (!new_node) {
+            const existingId = this.proxies_map.get(node.uri_api);
+            const existingNode = this.nodes.get(existingId);
+            if (existingNode) {
+                parent.children_counter++;
+                this.forced_edges.push({
+                    source: parent?.id,
+                    target: existingNode?.id
+                });
+                var children = this.tree_parents_map2.get(node.remote_id);
+                if (children?.length > 0) {
+                    children.forEach(child => {
+                        !this.filterNode(child) && this.linkToNode(child, existingNode);
+                    });
+                }
+            }
             return;
         }
         parent.children_counter++;

--- a/src/utils/Splinter.js
+++ b/src/utils/Splinter.js
@@ -991,20 +991,37 @@ class Splinter {
                 value.attributes.hasFolderAboutIt.forEach(folder => {
                     let jsonNode = this.tree_map.get(folder);
                     const splitName = jsonNode.dataset_relative_path.split('/');
+                    const lastPath = splitName[splitName.length - 1];
+                    const localId = value.attributes?.localId?.[0];
+                    const proxyTarget = this.proxies_map.get(jsonNode.uri_api);
+
+                    // Skip if this folder represents the same Subject/Sample node
+                    if ((proxyTarget && proxyTarget === value.id) ||
+                        (localId && lastPath === localId) ||
+                        (localId && jsonNode.basename === localId)) {
+                        // Make sure the tree node references the existing graph node
+                        let treeEntry = this.tree_map.get(jsonNode.uri_api);
+                        if (treeEntry) {
+                            treeEntry.graph_reference = value;
+                            this.tree_map.set(jsonNode.uri_api, treeEntry);
+                        }
+                        return;
+                    }
+
                     let newName = jsonNode.basename;
-                    if ( value.type === rdfTypes.Subject.key && value.attributes?.localId?.[0] == splitName[splitName.length - 1] ) {
+                    if ( value.type === rdfTypes.Subject.key && localId == lastPath ) {
                         newName = splitName[0]
                     }
 
-                    if ( value.type === rdfTypes.Sample.key && value.attributes?.localId?.[0] == splitName[splitName.length - 1] ) {
+                    if ( value.type === rdfTypes.Sample.key && localId == lastPath ) {
                         newName = splitName[0] + "/" + newName
                     }
 
-                    if ( value.type === rdfTypes.Performance.key && value.attributes?.localId?.[0] == splitName[splitName.length - 1] ) {
+                    if ( value.type === rdfTypes.Performance.key && localId == lastPath ) {
                         newName = splitName[0] + "/" + newName
                     }
 
-                    if ( value.type === rdfTypes.Site.key && value.attributes?.localId?.[0] ) {
+                    if ( value.type === rdfTypes.Site.key && localId ) {
                         newName = splitName[0] + "/" + newName
                     }
 
@@ -1072,7 +1089,9 @@ class Splinter {
             }
         }
         const new_node = this.buildNodeFromJson(node, level);
-        if ( parent ) {
+        if (!new_node || !parent) {
+            return;
+        }
         parent.children_counter++;
         new_node.parent = parent;
         new_node.id = parent.id + new_node.id;
@@ -1081,7 +1100,7 @@ class Splinter {
             target: new_node?.id
         });
         new_node.childLinks = [];
-        if ( !this.nodes.get(new_node.id) ) {
+        if (!this.nodes.get(new_node.id)) {
             this.nodes.set(new_node.id, this.factory.createNode(new_node));
             var children = this.tree_parents_map2.get(node.remote_id);
             if (children?.length > 0) {
@@ -1090,14 +1109,13 @@ class Splinter {
                 });
             }
         }
-        }
     }
 
 
     buildNodeFromJson(item, level) {
         const node_id = this.proxies_map.get(item.uri_api);
         if (node_id) {
-            return this.nodes.get(node_id);
+            return undefined;
         }
         const new_node = {
             id: item.uri_api,

--- a/src/utils/Splinter.js
+++ b/src/utils/Splinter.js
@@ -1005,6 +1005,12 @@ class Splinter {
                             treeEntry.graph_reference = value;
                             this.tree_map.set(jsonNode.uri_api, treeEntry);
                         }
+                        const dupChildren = this.tree_parents_map2.get(jsonNode.remote_id);
+                        dupChildren?.forEach(child => {
+                            if (!this.filterNode(child)) {
+                                this.linkToNode(child, value);
+                            }
+                        });
                         return;
                     }
 

--- a/src/utils/Splinter.js
+++ b/src/utils/Splinter.js
@@ -993,7 +993,7 @@ class Splinter {
                     const splitName = jsonNode.dataset_relative_path.split('/');
                     const lastPath = splitName[splitName.length - 1];
                     const localId = value.attributes?.localId?.[0];
-                    const proxyTarget = this.proxies_map.get(jsonNode.uri_api);
+                    const proxyTarget = this.proxies_map.get(jsonNode.remote_id);
 
                     // Skip if this folder represents the same Subject/Sample node
                     if ((proxyTarget && proxyTarget === value.id) ||
@@ -1003,7 +1003,10 @@ class Splinter {
                         let treeEntry = this.tree_map.get(jsonNode.uri_api);
                         if (treeEntry) {
                             treeEntry.graph_reference = value;
+                            value.tree_reference = treeEntry;
                             this.tree_map.set(jsonNode.uri_api, treeEntry);
+                            this.tree_map.set(jsonNode.remote_id, treeEntry);
+                            this.tree_map.set(value.id, treeEntry);
                         }
                         const dupChildren = this.tree_parents_map2.get(jsonNode.remote_id);
                         dupChildren?.forEach(child => {
@@ -1099,7 +1102,7 @@ class Splinter {
             return;
         }
         if (!new_node) {
-            const existingId = this.proxies_map.get(node.uri_api);
+            const existingId = this.proxies_map.get(node.remote_id);
             const existingNode = this.nodes.get(existingId);
             if (existingNode) {
                 parent.children_counter++;
@@ -1137,7 +1140,7 @@ class Splinter {
 
 
     buildNodeFromJson(item, level) {
-        const node_id = this.proxies_map.get(item.uri_api);
+        const node_id = this.proxies_map.get(item.remote_id);
         if (node_id) {
             return undefined;
         }


### PR DESCRIPTION
## Summary
- avoid adding folder nodes when json path matches the subject/sample
- don't mutate original nodes when skipping folder nodes

## Testing
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_686ca8d96a3c8321a227b00340c5a0d3