### PR TITLE
Update tests for new workflow

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,28 +1,43 @@
 name: SDS Viewer Workflow
 
-# Controls when the workflow will run
 on:
-  workflow_run:
-    workflows: ["pages build and deployment"]
-    types:
-      - completed
+  push:
+    branches:
+      - "master"
+      - "development"
+  pull_request:
+    branches:
+      - "master"
+      - "development"
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   sds_viewer_test:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-22.04
+    container: lironavon/docker-puppeteer-container:14.16.0
     env:
       CI: true
     steps:
       - uses: actions/checkout@v4
+
       - name: Use Node.js 18.x
         uses: actions/setup-node@v4
         with:
           node-version: 18.x
-      - name: SDS Viewer elements snapshot test
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Build the application (optional if required before dev)
+        run: yarn build
+
+      - name: Start development server in background
         run: |
-          yarn
-          npm run e2e_test
+          yarn run dev &
+          npx wait-on http://localhost:3000
+        env:
+          CI: true
+
+      - name: Run E2E snapshot tests
+        run: npm run e2e_test
         env:
           CI: true

--- a/__tests__/e2e.test.js
+++ b/__tests__/e2e.test.js
@@ -12,7 +12,7 @@ const path = require('path');
 var scriptName = path.basename(__filename, '.js');
 
 
-const DEV_URL = 'https://metacell.github.io/sds-viewer/'
+const DEV_URL = process.env.DEV_URL || 'http://localhost:3000/'
 const DATASET_ID = '0a5a2827-2b39-4085-87ea-2b7fbbe27cc8'
 
 //SNAPSHOT


### PR DESCRIPTION
## Summary
- run e2e tests against the local dev server
- allow overriding test DEV_URL via environment variable
- launch dev server in GitHub Actions CI

## Testing
- `npm run e2e_test` *(fails: jest not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_b_686e614300f48321845db5b07bfac0b2