### PR TITLE
Add group chip options, full vertical names, and resizable sidebar

### DIFF
--- a/src/components/GraphViewer/GraphViewer.js
+++ b/src/components/GraphViewer/GraphViewer.js
@@ -327,7 +327,16 @@ const GraphViewer = (props) => {
         linkCanvasObjectMode={'replace'}
         onLinkHover={handleLinkHover}
         // Override drawing of canvas objects, draw an image as a node
-        nodeCanvasObject={(node, ctx) => paintNode(node, ctx, hoverNode, selectedNode, nodeSelected, previouslySelectedNodes)}
+        nodeCanvasObject={(node, ctx) =>
+          paintNode(
+            node,
+            ctx,
+            hoverNode,
+            selectedNode,
+            nodeSelected,
+            previouslySelectedNodes,
+            selectedLayout.layout === LEFT_RIGHT.layout
+          )}
         nodeCanvasObjectMode={node => 'replace'}
         nodeVal = { node => {
           if ( selectedLayout.layout === TOP_DOWN.layout ){

--- a/src/components/NodeDetailView/Details/SubjectDetails.js
+++ b/src/components/NodeDetailView/Details/SubjectDetails.js
@@ -41,7 +41,7 @@ const SubjectDetails = (props) => {
                         if ( property.isGroup ){
                             return (<Box className="tab-content-row">
                                         <Typography component="label">{property.label}</Typography>
-                                        <SimpleLinkedChip chips={[{ value : node.graph_node.attributes[property.property]}]} node={getGroupNode(node.graph_node.attributes[property.property]?.[0], node)} />
+                                        <SimpleLinkedChip chips={[node.graph_node.attributes[property.property]]} node={getGroupNode(node.graph_node.attributes[property.property]?.[0], node)} />
                                     </Box>)
                         }
 

--- a/src/components/NodeDetailView/Details/Views/SimpleChip.js
+++ b/src/components/NodeDetailView/Details/Views/SimpleChip.js
@@ -1,14 +1,78 @@
-import React from "react";
-import {
-  Box,
-  Chip
-} from "@material-ui/core";
+import React, { useState } from "react";
+import { Box, Chip, Menu, MenuItem } from "@material-ui/core";
 
-const SimpleChip = ({chips}) => {
+const SimpleChip = ({ chips }) => {
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [selectedItem, setSelectedItem] = useState(null);
+
+  const isUrl = (value) => {
+    if (!value) return false;
+    try {
+      new URL(value);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  const normalize = (item) =>
+    typeof item === "string" ? { value: item } : item;
+
+  const handleClick = (item) => {
+    const url = item?.link || (isUrl(item?.value) ? item?.value : null);
+    if (url) {
+      window.open(url, "_blank");
+    }
+  };
+
+  const handleContextMenu = (event, item) => {
+    event.preventDefault();
+    setAnchorEl(event.currentTarget);
+    setSelectedItem(item);
+  };
+
+  const handleMenuClose = () => {
+    setAnchorEl(null);
+    setSelectedItem(null);
+  };
+
+  const handleCopyId = () => {
+    const copyValue = selectedItem?.id || selectedItem?.link || selectedItem?.value;
+    if (copyValue) {
+      navigator.clipboard.writeText(copyValue);
+    }
+    handleMenuClose();
+  };
+
+  const handleOpenNewTab = () => {
+    const url = selectedItem?.link || selectedItem?.id || selectedItem?.value;
+    if (isUrl(url)) {
+      window.open(url, "_blank");
+    }
+    handleMenuClose();
+  };
+
   return (
     <Box className="chip-overflow noscrollbar">
-      { chips?.map((item, index) => <Chip key={`${item}_${index}`} label={item} /> ) }
+      {chips?.map((rawItem, index) => {
+        const item = normalize(rawItem);
+        return (
+          <Chip
+            key={`${item?.value}_${index}`}
+            label={item?.value}
+            onClick={() => handleClick(item)}
+            onContextMenu={(e) => handleContextMenu(e, item)}
+          />
+        );
+      })}
+      <Menu anchorEl={anchorEl} keepMounted open={Boolean(anchorEl)} onClose={handleMenuClose}>
+        <MenuItem onClick={handleCopyId}>Copy ID</MenuItem>
+        {(selectedItem?.link || isUrl(selectedItem?.id) || isUrl(selectedItem?.value)) && (
+          <MenuItem onClick={handleOpenNewTab}>Open in new tab</MenuItem>
+        )}
+      </Menu>
     </Box>
-  )
-}
+  );
+};
+
 export default SimpleChip;

--- a/src/components/NodeDetailView/Details/Views/SimpleLinkedChip.js
+++ b/src/components/NodeDetailView/Details/Views/SimpleLinkedChip.js
@@ -97,7 +97,6 @@ const SimpleChip = ({ chips, node }) => {
         )
       )}
       <Menu anchorEl={anchorEl} keepMounted open={Boolean(anchorEl)} onClose={handleMenuClose}>
-        <MenuItem onClick={handleCopyId}>Copy ID</MenuItem>
         {(selectedItem?.link || isUrl(selectedItem?.id) || isUrl(selectedItem?.value)) && (
           <MenuItem onClick={handleOpenNewTab}>Open in new tab</MenuItem>
         )}

--- a/src/components/NodeDetailView/Details/Views/SimpleLinkedChip.js
+++ b/src/components/NodeDetailView/Details/Views/SimpleLinkedChip.js
@@ -57,14 +57,15 @@ const SimpleChip = ({ chips, node }) => {
   };
 
   const handleCopyId = () => {
-    if (selectedItem?.value) {
-      navigator.clipboard.writeText(selectedItem.value);
+    const copyValue = selectedItem?.id || selectedItem?.link || selectedItem?.value;
+    if (copyValue) {
+      navigator.clipboard.writeText(copyValue);
     }
     handleMenuClose();
   };
 
   const handleOpenNewTab = () => {
-    const url = selectedItem?.link || selectedItem?.value;
+    const url = selectedItem?.link || selectedItem?.id || selectedItem?.value;
     if (url) {
       window.open(url, '_blank');
     }
@@ -97,7 +98,7 @@ const SimpleChip = ({ chips, node }) => {
       )}
       <Menu anchorEl={anchorEl} keepMounted open={Boolean(anchorEl)} onClose={handleMenuClose}>
         <MenuItem onClick={handleCopyId}>Copy ID</MenuItem>
-        {(selectedItem?.link || isUrl(selectedItem?.value)) && (
+        {(selectedItem?.link || isUrl(selectedItem?.id) || isUrl(selectedItem?.value)) && (
           <MenuItem onClick={handleOpenNewTab}>Open in new tab</MenuItem>
         )}
       </Menu>

--- a/src/components/NodeDetailView/Details/Views/SimpleLinkedChip.js
+++ b/src/components/NodeDetailView/Details/Views/SimpleLinkedChip.js
@@ -1,45 +1,108 @@
-import React from "react";
+import React, { useState } from "react";
 import {
   Box,
-  Chip
+  Chip,
+  Menu,
+  MenuItem
 } from "@material-ui/core";
 import { useDispatch } from 'react-redux';
 import { selectGroup } from '../../../../redux/actions';
 import { GRAPH_SOURCE } from '../../../../constants';
 
 
-const SimpleChip = ({chips, node}) => {
+const SimpleChip = ({ chips, node }) => {
   const dispatch = useDispatch();
 
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [selectedItem, setSelectedItem] = useState(null);
+
+  const isUrl = (value) => {
+    if (!value) return false;
+    try {
+      new URL(value);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
   const handleClick = (item, node) => {
-    if ( item.link ){
-      window.open(item.link, '_blank')
-    } else if ( item.value ) {
-      let urlCheck = new RegExp("([a-zA-Z0-9]+://)?([a-zA-Z0-9_]+:[a-zA-Z0-9_]+@)?([a-zA-Z0-9.-]+\\.[A-Za-z]{2,4})(:[0-9]+)?(/.*)?");
-      if(urlCheck.test(item.value)) {
-        window.open(item.value, '_blank')
-      } else {
-        if ( node ) {
-          dispatch(selectGroup({
+    if (item.link) {
+      window.open(item.link, '_blank');
+    } else if (item.value) {
+      if (isUrl(item.value)) {
+        window.open(item.value, '_blank');
+      } else if (node) {
+        dispatch(
+          selectGroup({
             dataset_id: node.dataset_id,
             graph_node: node?.id,
             tree_node: node?.tree_reference?.id,
-            source: GRAPH_SOURCE
-          }));
-        }
+            source: GRAPH_SOURCE,
+          })
+        );
       }
     }
-  }
+  };
+
+  const handleContextMenu = (event, item) => {
+    event.preventDefault();
+    setAnchorEl(event.currentTarget);
+    setSelectedItem(item);
+  };
+
+  const handleMenuClose = () => {
+    setAnchorEl(null);
+    setSelectedItem(null);
+  };
+
+  const handleCopyId = () => {
+    if (selectedItem?.value) {
+      navigator.clipboard.writeText(selectedItem.value);
+    }
+    handleMenuClose();
+  };
+
+  const handleOpenNewTab = () => {
+    const url = selectedItem?.link || selectedItem?.value;
+    if (url) {
+      window.open(url, '_blank');
+    }
+    handleMenuClose();
+  };
 
   return (
     <Box className="chip-overflow noscrollbar">
-      { chips?.map((item, index) => ( node === undefined
-        ? item.link ? 
-        (<Chip label={item?.value} onClick={() => handleClick(item, null)}/>)
-        : (<Chip label={item?.value} />)
-        : (<Chip label={item?.value} onClick={() => handleClick(item, node)}/>)))
-      }
+      {chips?.map((item, index) =>
+        node === undefined ? (
+          item.link ? (
+            <Chip
+              label={item?.value}
+              onClick={() => handleClick(item, null)}
+              onContextMenu={(e) => handleContextMenu(e, item)}
+            />
+          ) : (
+            <Chip
+              label={item?.value}
+              onContextMenu={(e) => handleContextMenu(e, item)}
+            />
+          )
+        ) : (
+          <Chip
+            label={item?.value}
+            onClick={() => handleClick(item, node)}
+            onContextMenu={(e) => handleContextMenu(e, item)}
+          />
+        )
+      )}
+      <Menu anchorEl={anchorEl} keepMounted open={Boolean(anchorEl)} onClose={handleMenuClose}>
+        <MenuItem onClick={handleCopyId}>Copy ID</MenuItem>
+        {(selectedItem?.link || isUrl(selectedItem?.value)) && (
+          <MenuItem onClick={handleOpenNewTab}>Open in new tab</MenuItem>
+        )}
+      </Menu>
     </Box>
-  )
-}
+  );
+};
+
 export default SimpleChip;

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { Box } from '@material-ui/core';
 import SidebarHeader from './Header';
 import SidebarContent from './List';
@@ -7,9 +7,39 @@ import SidebarFooter from './Footer';
 const Sidebar = (props) => {
   const [expand, setExpand] = useState(true);
   const [searchTerm, setSearchTerm] = useState('');
+  const [width, setWidth] = useState(300);
+  const [isResizing, setIsResizing] = useState(false);
+  const sidebarRef = useRef(null);
+
+  const startResizing = (e) => {
+    setIsResizing(true);
+    e.preventDefault();
+  };
+
+  useEffect(() => {
+    const handleMouseMove = (e) => {
+      if (!isResizing || !expand) return;
+      const sidebarLeft = sidebarRef.current?.getBoundingClientRect().left || 0;
+      const newWidth = e.clientX - sidebarLeft;
+      if (newWidth > 200) {
+        setWidth(newWidth);
+      }
+    };
+    const stopResizing = () => setIsResizing(false);
+    document.addEventListener('mousemove', handleMouseMove);
+    document.addEventListener('mouseup', stopResizing);
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', stopResizing);
+    };
+  }, [isResizing, expand]);
 
   return (
-    <Box className={'sidebar' + (!expand ? ' shrink' : '')}>
+    <Box
+      ref={sidebarRef}
+      className={'sidebar' + (!expand ? ' shrink' : '')}
+      style={{ width: expand ? width : 66 }}
+    >
       <SidebarHeader setExpand={setExpand} expand={expand} setSearchTerm={setSearchTerm} searchTerm={searchTerm} />
       <SidebarContent setExpand={setExpand} expand={expand} searchTerm={searchTerm} />
       <SidebarFooter
@@ -17,6 +47,7 @@ const Sidebar = (props) => {
         expand={expand}
         setOpenDatasetsListDialog={props.setOpenDatasetsListDialog}
       />
+      {expand && <Box className="sidebar-resizer" onMouseDown={startResizing} />}
     </Box>
   );
 };

--- a/src/theme.js
+++ b/src/theme.js
@@ -490,6 +490,7 @@ const theme = createTheme({
           display: 'flex',
           flexDirection: 'column',
           transition: primaryTransition,
+          position: 'relative',
           '&.shrink': {
             width: '4.125rem',
             transition: primaryTransition,
@@ -664,14 +665,14 @@ const theme = createTheme({
               marginRight: '0.625rem',
               flexShrink: 0,
             },
-            '& .labelText': {
+          '& .labelText': {
               fontWeight: 'normal',
               flexGrow: 1,
               fontSize: '0.8125rem',
               lineHeight: '1rem',
               color: whiteColor,
-            },
-            '& .MuiTreeItem-group': {
+          },
+          '& .MuiTreeItem-group': {
               paddingLeft: '1.4375rem',
               margin: 0,
             },
@@ -830,7 +831,7 @@ const theme = createTheme({
               },
             },
 
-            '& .no-instance': {
+          '& .no-instance': {
               fontSize: '0.75rem',
               display: 'flex',
               alignItems: 'center',
@@ -841,6 +842,14 @@ const theme = createTheme({
               color: grey100,
               textAlign: 'center',
             },
+          },
+          '&-resizer': {
+            width: '0.3125rem',
+            cursor: 'col-resize',
+            position: 'absolute',
+            right: 0,
+            top: 0,
+            bottom: 0,
           },
           '&-footer': {
             boxShadow: `0 -4.75rem 3.0625rem -2.5625rem ${secondaryColor}`,

--- a/src/utils/GraphViewerHelper.js
+++ b/src/utils/GraphViewerHelper.js
@@ -68,7 +68,15 @@ const roundRect = (ctx, x, y, width, height, radius, color, alpha) => {
   ctx.fill();
 };
 
-export const paintNode = (node, ctx, hoverNode, selectedNode, nodeSelected, previouslySelectedNodes) =>  {
+export const paintNode = (
+  node,
+  ctx,
+  hoverNode,
+  selectedNode,
+  nodeSelected,
+  previouslySelectedNodes,
+  showFullName = false
+) =>  {
       const size = 7.5;
       const nodeImageSize = [size * 2.4, size * 2.4];
       const hoverRectDimensions = [size * 4.2, size * 4.2];
@@ -105,10 +113,11 @@ export const paintNode = (node, ctx, hoverNode, selectedNode, nodeSelected, prev
       ctx.textAlign = 'center';
       ctx.textBaseline = 'top';
       let nodeName = node.name;
-      if (nodeName.length > 10) {
+      if (Array.isArray(nodeName)) {
+        nodeName = nodeName[0];
+      }
+      if (!showFullName && nodeName?.length > 10) {
         nodeName = nodeName.substr(0, 9).concat('...');
-      } else if ( Array.isArray(nodeName) ){
-        nodeName = nodeName[0]?.substr(0, 9).concat('...');
       }
       const textProps = [nodeName, node.x, textHoverPosition[1]];
       if (node === hoverNode || node?.id === selectedNode?.id || node?.id === nodeSelected?.id ) {

--- a/src/utils/Splinter.js
+++ b/src/utils/Splinter.js
@@ -533,6 +533,19 @@ class Splinter {
             return link;
         })
         this.edges = temp_edges;
+        // update "isAbout" references for subject and sample nodes to include links
+        this.nodes.forEach((n, k) => {
+            if (n.type === rdfTypes.Subject.key || n.type === rdfTypes.Sample.key) {
+                if (n?.attributes?.isAbout) {
+                    const about = [];
+                    n.attributes.isAbout.forEach(a => {
+                        about.push(that.replaceNode(a));
+                    });
+                    n.attributes.isAbout = about;
+                    this.nodes.set(k, n);
+                }
+            }
+        });
         return dataset_node;
     }
 

--- a/src/utils/Splinter.js
+++ b/src/utils/Splinter.js
@@ -977,14 +977,15 @@ class Splinter {
             }
         });
 
-        // update attribute references for subject and sample nodes after organizing groups
+        // update group attribute references for subject and sample nodes after organizing groups
         let that = this;
+        const groupKeys = Object.keys(config.groups.order);
         this.nodes.forEach((n, k) => {
             if (n.type === rdfTypes.Subject.key || n.type === rdfTypes.Sample.key) {
-                Object.keys(n?.attributes || {}).forEach((attr) => {
-                    const value = n.attributes[attr];
+                groupKeys.forEach((attr) => {
+                    const value = n.attributes?.[attr];
                     if (Array.isArray(value)) {
-                        const hasLink = value.some((a) =>
+                        n.attributes[attr] = value.map((a) =>
                             typeof a === "string" && (
                                 a.startsWith("http") ||
                                 a.includes(rdfTypes.NCBITaxon.key) ||
@@ -992,20 +993,9 @@ class Splinter {
                                 a.includes(rdfTypes.UBERON.key) ||
                                 a.includes(rdfTypes.RRID.key)
                             )
+                                ? that.replaceNode(a)
+                                : { value: a }
                         );
-                        if (hasLink) {
-                            n.attributes[attr] = value.map((a) =>
-                                typeof a === "string" && (
-                                    a.startsWith("http") ||
-                                    a.includes(rdfTypes.NCBITaxon.key) ||
-                                    a.includes(rdfTypes.PATO.key) ||
-                                    a.includes(rdfTypes.UBERON.key) ||
-                                    a.includes(rdfTypes.RRID.key)
-                                )
-                                    ? that.replaceNode(a)
-                                    : { value: a }
-                            );
-                        }
                     }
                 });
                 this.nodes.set(k, n);

--- a/src/utils/Splinter.js
+++ b/src/utils/Splinter.js
@@ -504,10 +504,13 @@ class Splinter {
         let that = this;
         dataset_node?.attributes?.isAbout?.forEach((a) => {
             if (
-                a?.includes(rdfTypes.NCBITaxon.key) ||
-                a?.includes(rdfTypes.PATO.key) ||
-                a?.includes(rdfTypes.UBERON.key) ||
-                a?.includes(rdfTypes.RRID.key)
+                typeof a === 'string' && (
+                    a.startsWith('http') ||
+                    a?.includes(rdfTypes.NCBITaxon.key) ||
+                    a?.includes(rdfTypes.PATO.key) ||
+                    a?.includes(rdfTypes.UBERON.key) ||
+                    a?.includes(rdfTypes.RRID.key)
+                )
             ) {
                 updatedAbout.push(that.replaceNode(a));
             } else {
@@ -519,16 +522,19 @@ class Splinter {
         let updateTechniques = [];
         dataset_node.attributes.protocolEmploysTechnique?.forEach((a) => {
             if (
-                a?.includes(rdfTypes.NCBITaxon.key) ||
-                a?.includes(rdfTypes.PATO.key) ||
-                a?.includes(rdfTypes.UBERON.key) ||
-                a?.includes(rdfTypes.RRID.key)
+                typeof a === 'string' && (
+                    a.startsWith('http') ||
+                    a?.includes(rdfTypes.NCBITaxon.key) ||
+                    a?.includes(rdfTypes.PATO.key) ||
+                    a?.includes(rdfTypes.UBERON.key) ||
+                    a?.includes(rdfTypes.RRID.key)
+                )
             ) {
                 let node = this.nodes.get(a);
                 if (node) {
                     updateTechniques.push({ value: node?.attributes.label[0], link: node?.id });
                 } else {
-                    updateTechniques.push({ value: a });
+                    updateTechniques.push({ value: a, link: a });
                 }
             } else {
                 updateTechniques.push({ value: a });
@@ -548,31 +554,6 @@ class Splinter {
             return link;
         })
         this.edges = temp_edges;
-        // update all attribute references for subject and sample nodes to include links
-        this.nodes.forEach((n, k) => {
-            if (n.type === rdfTypes.Subject.key || n.type === rdfTypes.Sample.key) {
-                Object.keys(n?.attributes || {}).forEach((attr) => {
-                    const value = n.attributes[attr];
-                    if (Array.isArray(value)) {
-                        n.attributes[attr] = value.map((a) => {
-                            if (
-                                typeof a === "string" &&
-                                (
-                                    a?.includes(rdfTypes.NCBITaxon.key) ||
-                                    a?.includes(rdfTypes.PATO.key) ||
-                                    a?.includes(rdfTypes.UBERON.key) ||
-                                    a?.includes(rdfTypes.RRID.key)
-                                )
-                            ) {
-                                return that.replaceNode(a);
-                            }
-                            return typeof a === "string" ? { value: a } : a;
-                        });
-                    }
-                });
-                this.nodes.set(k, n);
-            }
-        });
         return dataset_node;
     }
 
@@ -993,6 +974,41 @@ class Splinter {
                         });
                     }
                 }
+            }
+        });
+
+        // update attribute references for subject and sample nodes after organizing groups
+        let that = this;
+        this.nodes.forEach((n, k) => {
+            if (n.type === rdfTypes.Subject.key || n.type === rdfTypes.Sample.key) {
+                Object.keys(n?.attributes || {}).forEach((attr) => {
+                    const value = n.attributes[attr];
+                    if (Array.isArray(value)) {
+                        const hasLink = value.some((a) =>
+                            typeof a === "string" && (
+                                a.startsWith("http") ||
+                                a.includes(rdfTypes.NCBITaxon.key) ||
+                                a.includes(rdfTypes.PATO.key) ||
+                                a.includes(rdfTypes.UBERON.key) ||
+                                a.includes(rdfTypes.RRID.key)
+                            )
+                        );
+                        if (hasLink) {
+                            n.attributes[attr] = value.map((a) =>
+                                typeof a === "string" && (
+                                    a.startsWith("http") ||
+                                    a.includes(rdfTypes.NCBITaxon.key) ||
+                                    a.includes(rdfTypes.PATO.key) ||
+                                    a.includes(rdfTypes.UBERON.key) ||
+                                    a.includes(rdfTypes.RRID.key)
+                                )
+                                    ? that.replaceNode(a)
+                                    : { value: a }
+                            );
+                        }
+                    }
+                });
+                this.nodes.set(k, n);
             }
         });
     }

--- a/src/utils/Splinter.js
+++ b/src/utils/Splinter.js
@@ -502,22 +502,36 @@ class Splinter {
         let updatedAbout = [];
         dataset_node.level = 1;
         let that = this;
-        dataset_node?.attributes?.isAbout?.forEach( (a) => {
-            updatedAbout.push(that.replaceNode(a));
+        dataset_node?.attributes?.isAbout?.forEach((a) => {
+            if (
+                a?.includes(rdfTypes.NCBITaxon.key) ||
+                a?.includes(rdfTypes.PATO.key) ||
+                a?.includes(rdfTypes.UBERON.key) ||
+                a?.includes(rdfTypes.RRID.key)
+            ) {
+                updatedAbout.push(that.replaceNode(a));
+            } else {
+                updatedAbout.push({ value: a });
+            }
         });
         dataset_node.attributes.isAbout = updatedAbout;
 
         let updateTechniques = [];
-        dataset_node.attributes.protocolEmploysTechnique?.forEach( (a) => {
-            if( a.includes(rdfTypes.NCBITaxon.key) || a.includes(rdfTypes.PATO.key) || a.includes(rdfTypes.UBERON.key) ) {
+        dataset_node.attributes.protocolEmploysTechnique?.forEach((a) => {
+            if (
+                a?.includes(rdfTypes.NCBITaxon.key) ||
+                a?.includes(rdfTypes.PATO.key) ||
+                a?.includes(rdfTypes.UBERON.key) ||
+                a?.includes(rdfTypes.RRID.key)
+            ) {
                 let node = this.nodes.get(a);
                 if (node) {
-                    updateTechniques.push({"value": node?.attributes.label[0], "link": node?.id});
+                    updateTechniques.push({ value: node?.attributes.label[0], link: node?.id });
                 } else {
-                    updateTechniques.push({"value": a});
+                    updateTechniques.push({ value: a });
                 }
             } else {
-                updateTechniques.push({"value": a});
+                updateTechniques.push({ value: a });
             }
         });
         dataset_node.attributes.protocolEmploysTechnique = updateTechniques;
@@ -537,12 +551,23 @@ class Splinter {
         // update all attribute references for subject and sample nodes to include links
         this.nodes.forEach((n, k) => {
             if (n.type === rdfTypes.Subject.key || n.type === rdfTypes.Sample.key) {
-                Object.keys(n?.attributes || {}).forEach(attr => {
+                Object.keys(n?.attributes || {}).forEach((attr) => {
                     const value = n.attributes[attr];
                     if (Array.isArray(value)) {
-                        n.attributes[attr] = value.map(a =>
-                            typeof a === 'string' ? that.replaceNode(a) : a
-                        );
+                        n.attributes[attr] = value.map((a) => {
+                            if (
+                                typeof a === "string" &&
+                                (
+                                    a?.includes(rdfTypes.NCBITaxon.key) ||
+                                    a?.includes(rdfTypes.PATO.key) ||
+                                    a?.includes(rdfTypes.UBERON.key) ||
+                                    a?.includes(rdfTypes.RRID.key)
+                                )
+                            ) {
+                                return that.replaceNode(a);
+                            }
+                            return typeof a === "string" ? { value: a } : a;
+                        });
                     }
                 });
                 this.nodes.set(k, n);

--- a/src/utils/Splinter.js
+++ b/src/utils/Splinter.js
@@ -455,14 +455,15 @@ class Splinter {
     }
 
     replaceNode(a) {
-        let newNode = {"value": a};
-        if( a?.includes(rdfTypes.NCBITaxon.key) || a?.includes(rdfTypes.PATO.key) || a?.includes(rdfTypes.UBERON.key) || a?.includes(rdfTypes.RRID.key) ) {
-            let node = this.nodes.get(a);
+        let newNode = { "value": a };
+        if (typeof a === 'string') {
+            const node = this.nodes.get(a);
             if (node) {
-                newNode = {"value": node?.attributes.label[0], "link": node?.id};
+                newNode = { "value": node?.attributes.label[0], "link": node?.id };
+            } else if (a.startsWith('http')) {
+                newNode = { "value": a, "link": a };
             }
         }
-
         return newNode;
     }
 
@@ -533,17 +534,18 @@ class Splinter {
             return link;
         })
         this.edges = temp_edges;
-        // update "isAbout" references for subject and sample nodes to include links
+        // update all attribute references for subject and sample nodes to include links
         this.nodes.forEach((n, k) => {
             if (n.type === rdfTypes.Subject.key || n.type === rdfTypes.Sample.key) {
-                if (n?.attributes?.isAbout) {
-                    const about = [];
-                    n.attributes.isAbout.forEach(a => {
-                        about.push(that.replaceNode(a));
-                    });
-                    n.attributes.isAbout = about;
-                    this.nodes.set(k, n);
-                }
+                Object.keys(n?.attributes || {}).forEach(attr => {
+                    const value = n.attributes[attr];
+                    if (Array.isArray(value)) {
+                        n.attributes[attr] = value.map(a =>
+                            typeof a === 'string' ? that.replaceNode(a) : a
+                        );
+                    }
+                });
+                this.nodes.set(k, n);
             }
         });
         return dataset_node;

--- a/src/utils/Splinter.js
+++ b/src/utils/Splinter.js
@@ -560,34 +560,37 @@ class Splinter {
     organise_subjects(target_node, link, groups, k, type){
         let parent = this.nodes.get(k);
         let keys = Object.keys(config.groups.order);
-        keys.forEach( key => {
+        keys.forEach(key => {
             let group = config.groups.order[key];
-            if ( target_node.attributes[key]?.[0] ) {
-                let source = this.nodes.get(target_node.attributes[key]?.[0]);
-                if ( source !== undefined ) {
-                    target_node.attributes[key][0] = source.attributes.label[0];
-                }
-                
-                const groupID = parent.id + "_" + target_node.attributes[key]?.[0].replace(/\s/g, "");
-                if ( this.nodes.get(groupID) === undefined ) {
-                    let name = target_node.attributes[key]?.[0];
+            if (target_node.attributes[key]?.[0]) {
+                // attributes may already be objects from previous passes
+                const raw = target_node.attributes[key][0];
+                const originalValue = typeof raw === "object" ? raw.value : raw;
 
+                let source = this.nodes.get(originalValue);
+                let label = originalValue;
+                if (source !== undefined) {
+                    label = source.attributes.label[0];
+                }
+
+                const groupID = parent.id + "_" + ("" + label).replace(/\s/g, "");
+                if (this.nodes.get(groupID) === undefined) {
                     const groupNode = {
                         id: groupID,
-                        name: name,
+                        name: label,
                         type: typesModel.NamedIndividual.group.type,
                         properties: key,
-                        parent : parent,
+                        parent: parent,
                         proxies: [],
                         level: parent.level + 1,
                         tree_reference: null,
                         children_counter: 0,
-                        collapsed : false,
-                        childLinks : [],
-                        samples : 0, 
-                        subjects : 0,
-                        publishedURI : "",
-                        dataset_id : this.dataset_id
+                        collapsed: false,
+                        childLinks: [],
+                        samples: 0,
+                        subjects: 0,
+                        publishedURI: "",
+                        dataset_id: this.dataset_id
                     };
                     let nodeF = this.factory.createNode(groupNode);
                     const img = new Image();
@@ -598,11 +601,14 @@ class Splinter {
                         source: parent.id,
                         target: nodeF.id
                     });
-                    this.groups[key] ? this.groups[key][nodeF.name] = nodeF :  this.groups[key] = {[nodeF.name] : nodeF};
+                    this.groups[key] ? this.groups[key][nodeF.name] = nodeF : this.groups[key] = {[nodeF.name]: nodeF};
                     parent = groupNode;
                 } else {
                     parent = this.nodes.get(groupID);
                 }
+
+                // preserve original identifier for chips
+                target_node.attributes[key] = this.replaceNode(target_node.attributes[key][0]);
             } else {
                 console.error("The group node already exists!", group.tag);
             }
@@ -977,30 +983,6 @@ class Splinter {
             }
         });
 
-        // update group attribute references for subject and sample nodes after organizing groups
-        let that = this;
-        const groupKeys = Object.keys(config.groups.order);
-        this.nodes.forEach((n, k) => {
-            if (n.type === rdfTypes.Subject.key || n.type === rdfTypes.Sample.key) {
-                groupKeys.forEach((attr) => {
-                    const value = n.attributes?.[attr];
-                    if (Array.isArray(value)) {
-                        n.attributes[attr] = value.map((a) =>
-                            typeof a === "string" && (
-                                a.startsWith("http") ||
-                                a.includes(rdfTypes.NCBITaxon.key) ||
-                                a.includes(rdfTypes.PATO.key) ||
-                                a.includes(rdfTypes.UBERON.key) ||
-                                a.includes(rdfTypes.RRID.key)
-                            )
-                                ? that.replaceNode(a)
-                                : { value: a }
-                        );
-                    }
-                });
-                this.nodes.set(k, n);
-            }
-        });
     }
 
 


### PR DESCRIPTION
## Summary
- add context menu to metadata group chips for copying IDs or opening URLs
- show full node names when using vertical graph layout
- allow dragging to resize the sidebar

## Testing
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*
- `npm install --no-save` *(fails: 403 Forbidden when fetching @babel/plugin-syntax-jsx)*

------
https://chatgpt.com/codex/tasks/task_b_68a099b858848321938e06b555ebe953