### PR TITLE
Preserve subject group IDs for chip context menus

### DIFF
--- a/src/components/NodeDetailView/Details/SubjectDetails.js
+++ b/src/components/NodeDetailView/Details/SubjectDetails.js
@@ -28,7 +28,7 @@ const SubjectDetails = (props) => {
 
         return n;
     }
-
+    
     return (
         <Box id={node?.graph_node?.id + detailsLabel}>
             <Divider />
@@ -39,10 +39,19 @@ const SubjectDetails = (props) => {
                     if ( property.visible ){
                         const propValue = node.graph_node.attributes[property.property]?.[0];
                         if ( property.isGroup ){
-                            return (<Box className="tab-content-row">
-                                        <Typography component="label">{property.label}</Typography>
-                                        <SimpleLinkedChip chips={[{ value : node.graph_node.attributes[property.property]}]} node={getGroupNode(node.graph_node.attributes[property.property]?.[0], node)} />
-                                    </Box>)
+                            const rawValue = node.graph_node.attributes[property.property];
+                            const propValue = Array.isArray(rawValue) ? rawValue[0] : rawValue;
+                            const normalizedArray = Array.isArray(rawValue) ? rawValue : [rawValue];
+  
+                            return (
+                                <Box className="tab-content-row">
+                                <Typography component="label">{property.label}</Typography>
+                                <SimpleLinkedChip
+                                    chips={[{ value: normalizedArray[0] }]}
+                                    node={getGroupNode(normalizedArray[0], node)}
+                                />
+                                </Box>
+                            );
                         }
 
                         else if ( isValidUrl(propValue) ){

--- a/src/components/NodeDetailView/Details/Views/SimpleLinkedChip.js
+++ b/src/components/NodeDetailView/Details/Views/SimpleLinkedChip.js
@@ -35,12 +35,12 @@ const SimpleChip = ({ chips, node }) => {
   return (
     <Box className="chip-overflow noscrollbar">
       {chips?.map((chip, index) => {
-        const item = typeof chip === 'object' ? chip : { value: chip };
+        const item = typeof chip === 'object' ? chip : { value: chip.value };
         const key = `${item.value}_${index}`;
         return (
           <Chip
             key={key}
-            label={item.value}
+            label={item.value?.value ? item.value.value : item.value}
             onClick={() => handleClick(item, node)}
             onContextMenu={(e) => handleContextMenu(e, item)}
           />

--- a/src/components/NodeDetailView/Details/Views/SimpleLinkedChip.js
+++ b/src/components/NodeDetailView/Details/Views/SimpleLinkedChip.js
@@ -1,45 +1,53 @@
 import React from "react";
-import {
-  Box,
-  Chip
-} from "@material-ui/core";
+import { Box, Chip } from "@material-ui/core";
 import { useDispatch } from 'react-redux';
 import { selectGroup } from '../../../../redux/actions';
 import { GRAPH_SOURCE } from '../../../../constants';
 
-
-const SimpleChip = ({chips, node}) => {
+const SimpleChip = ({ chips, node }) => {
   const dispatch = useDispatch();
 
-  const handleClick = (item, node) => {
-    if ( item.link ){
-      window.open(item.link, '_blank')
-    } else if ( item.value ) {
-      let urlCheck = new RegExp("([a-zA-Z0-9]+://)?([a-zA-Z0-9_]+:[a-zA-Z0-9_]+@)?([a-zA-Z0-9.-]+\\.[A-Za-z]{2,4})(:[0-9]+)?(/.*)?");
-      if(urlCheck.test(item.value)) {
-        window.open(item.value, '_blank')
-      } else {
-        if ( node ) {
-          dispatch(selectGroup({
-            dataset_id: node.dataset_id,
-            graph_node: node?.id,
-            tree_node: node?.tree_reference?.id,
-            source: GRAPH_SOURCE
-          }));
-        }
-      }
+  const handleClick = (item, groupNode) => {
+    if (item.link) {
+      window.open(item.link, '_blank');
+      return;
     }
-  }
+    const value = item.value;
+    const urlCheck = new RegExp("([a-zA-Z0-9]+://)?([a-zA-Z0-9_]+:[a-zA-Z0-9_]+@)?([a-zA-Z0-9.-]+\\.[A-Za-z]{2,4})(:[0-9]+)?(/.*)?");
+    if (urlCheck.test(value)) {
+      window.open(value, '_blank');
+    } else if (groupNode) {
+      dispatch(selectGroup({
+        dataset_id: groupNode.dataset_id,
+        graph_node: groupNode?.id,
+        tree_node: groupNode?.tree_reference?.id,
+        source: GRAPH_SOURCE
+      }));
+    }
+  };
+
+  const handleContextMenu = (e, item) => {
+    e.preventDefault();
+    const url = item.link || item.value;
+    navigator.clipboard.writeText(url);
+  };
 
   return (
     <Box className="chip-overflow noscrollbar">
-      { chips?.map((item, index) => ( node === undefined
-        ? item.link ? 
-        (<Chip label={item?.value} onClick={() => handleClick(item, null)}/>)
-        : (<Chip label={item?.value} />)
-        : (<Chip label={item?.value} onClick={() => handleClick(item, node)}/>)))
-      }
+      {chips?.map((chip, index) => {
+        const item = typeof chip === 'object' ? chip : { value: chip };
+        const key = `${item.value}_${index}`;
+        return (
+          <Chip
+            key={key}
+            label={item.value}
+            onClick={() => handleClick(item, node)}
+            onContextMenu={(e) => handleContextMenu(e, item)}
+          />
+        );
+      })}
     </Box>
-  )
-}
+  );
+};
+
 export default SimpleChip;

--- a/src/utils/Splinter.js
+++ b/src/utils/Splinter.js
@@ -472,13 +472,16 @@ class Splinter {
     }
 
     replaceNode(a) {
-        let newNode = { "value": a };
+        if (a && typeof a === 'object') {
+            return a;
+        }
+        let newNode = { value: a };
         if (typeof a === 'string') {
             const node = this.nodes.get(a);
             if (node) {
-                newNode = { "value": node?.attributes.label[0], "link": node?.id };
+                newNode = { value: node?.attributes.label[0], link: node?.id };
             } else if (a.startsWith('http')) {
-                newNode = { "value": a, "link": a };
+                newNode = { value: a, link: a };
             }
         }
         return newNode;

--- a/src/utils/Splinter.js
+++ b/src/utils/Splinter.js
@@ -211,7 +211,9 @@ class Splinter {
                         if ( n?.attributes[key] ) {
                             let groupKeys = Object.keys(that.groups[key]);
                             groupKeys.forEach( groupKey => {
-                                if ( n?.attributes[key][0] === groupKey ) {
+                                const attrVal = n?.attributes[key][0];
+                                const attrName = typeof attrVal === 'object' ? attrVal.value : attrVal;
+                                if ( attrName === groupKey ) {
                                     const groupNodes = filteredNodes?.filter(n => n.name == groupKey);
                                     groupNodes?.forEach( groupNode => {
                                         if ( n?.id?.includes(groupNode.id) ) {
@@ -271,6 +273,21 @@ class Splinter {
             }
             return true;
         });
+
+        // After computing links, add link information to subject and sample attributes
+        this.nodes.forEach((n, k) => {
+            if (n.type === rdfTypes.Subject.key || n.type === rdfTypes.Sample.key) {
+                const attrs = n.attributes || {};
+                Object.keys(attrs).forEach(attr => {
+                    const arr = attrs[attr];
+                    if (Array.isArray(arr)) {
+                        attrs[attr] = arr.map(a => typeof a === 'object' ? a : that.replaceNode(a));
+                    }
+                });
+                this.nodes.set(k, n);
+            }
+        });
+
         return {
             nodes: filteredNodes,
             links: newCleanLinks,
@@ -455,14 +472,15 @@ class Splinter {
     }
 
     replaceNode(a) {
-        let newNode = {"value": a};
-        if( a?.includes(rdfTypes.NCBITaxon.key) || a?.includes(rdfTypes.PATO.key) || a?.includes(rdfTypes.UBERON.key) || a?.includes(rdfTypes.RRID.key) ) {
-            let node = this.nodes.get(a);
+        let newNode = { "value": a };
+        if (typeof a === 'string') {
+            const node = this.nodes.get(a);
             if (node) {
-                newNode = {"value": node?.attributes.label[0], "link": node?.id};
+                newNode = { "value": node?.attributes.label[0], "link": node?.id };
+            } else if (a.startsWith('http')) {
+                newNode = { "value": a, "link": a };
             }
         }
-
         return newNode;
     }
 
@@ -501,22 +519,42 @@ class Splinter {
         let updatedAbout = [];
         dataset_node.level = 1;
         let that = this;
-        dataset_node?.attributes?.isAbout?.forEach( (a) => {
-            updatedAbout.push(that.replaceNode(a));
+        dataset_node?.attributes?.isAbout?.forEach((a) => {
+            if (
+                typeof a === 'string' && (
+                    a.startsWith('http') ||
+                    a.includes(rdfTypes.NCBITaxon.key) ||
+                    a.includes(rdfTypes.PATO.key) ||
+                    a.includes(rdfTypes.UBERON.key) ||
+                    a.includes(rdfTypes.RRID.key)
+                )
+            ) {
+                updatedAbout.push(that.replaceNode(a));
+            } else {
+                updatedAbout.push({ value: a });
+            }
         });
         dataset_node.attributes.isAbout = updatedAbout;
 
         let updateTechniques = [];
-        dataset_node.attributes.protocolEmploysTechnique?.forEach( (a) => {
-            if( a.includes(rdfTypes.NCBITaxon.key) || a.includes(rdfTypes.PATO.key) || a.includes(rdfTypes.UBERON.key) ) {
+        dataset_node.attributes.protocolEmploysTechnique?.forEach((a) => {
+            if (
+                typeof a === 'string' && (
+                    a.startsWith('http') ||
+                    a.includes(rdfTypes.NCBITaxon.key) ||
+                    a.includes(rdfTypes.PATO.key) ||
+                    a.includes(rdfTypes.UBERON.key) ||
+                    a.includes(rdfTypes.RRID.key)
+                )
+            ) {
                 let node = this.nodes.get(a);
                 if (node) {
-                    updateTechniques.push({"value": node?.attributes.label[0], "link": node?.id});
+                    updateTechniques.push({ value: node?.attributes.label[0], link: node?.id });
                 } else {
-                    updateTechniques.push({"value": a});
+                    updateTechniques.push({ value: a, link: a });
                 }
             } else {
-                updateTechniques.push({"value": a});
+                updateTechniques.push({ value: a });
             }
         });
         dataset_node.attributes.protocolEmploysTechnique = updateTechniques;
@@ -539,34 +577,37 @@ class Splinter {
     organise_subjects(target_node, link, groups, k, type){
         let parent = this.nodes.get(k);
         let keys = Object.keys(config.groups.order);
-        keys.forEach( key => {
+        keys.forEach(key => {
             let group = config.groups.order[key];
-            if ( target_node.attributes[key]?.[0] ) {
-                let source = this.nodes.get(target_node.attributes[key]?.[0]);
-                if ( source !== undefined ) {
-                    target_node.attributes[key][0] = source.attributes.label[0];
-                }
-                
-                const groupID = parent.id + "_" + target_node.attributes[key]?.[0].replace(/\s/g, "");
-                if ( this.nodes.get(groupID) === undefined ) {
-                    let name = target_node.attributes[key]?.[0];
+            if (target_node.attributes[key]?.[0]) {
+                // attributes may already be objects from previous passes
+                const raw = target_node.attributes[key][0];
+                const originalValue = typeof raw === "object" ? raw.value : raw;
 
+                let source = this.nodes.get(originalValue);
+                let label = originalValue;
+                if (source !== undefined) {
+                    label = source.attributes.label[0];
+                }
+
+                const groupID = parent.id + "_" + ("" + label).replace(/\s/g, "");
+                if (this.nodes.get(groupID) === undefined) {
                     const groupNode = {
                         id: groupID,
-                        name: name,
+                        name: label,
                         type: typesModel.NamedIndividual.group.type,
                         properties: key,
-                        parent : parent,
+                        parent: parent,
                         proxies: [],
                         level: parent.level + 1,
                         tree_reference: null,
                         children_counter: 0,
-                        collapsed : false,
-                        childLinks : [],
-                        samples : 0, 
-                        subjects : 0,
-                        publishedURI : "",
-                        dataset_id : this.dataset_id
+                        collapsed: false,
+                        childLinks: [],
+                        samples: 0,
+                        subjects: 0,
+                        publishedURI: "",
+                        dataset_id: this.dataset_id
                     };
                     let nodeF = this.factory.createNode(groupNode);
                     const img = new Image();
@@ -577,11 +618,15 @@ class Splinter {
                         source: parent.id,
                         target: nodeF.id
                     });
-                    this.groups[key] ? this.groups[key][nodeF.name] = nodeF :  this.groups[key] = {[nodeF.name] : nodeF};
+                    this.groups[key] ? this.groups[key][nodeF.name] = nodeF : this.groups[key] = {[nodeF.name]: nodeF};
                     parent = groupNode;
                 } else {
                     parent = this.nodes.get(groupID);
                 }
+
+                // preserve the original identifier so chips can expose links
+                target_node.attributes[key][0] = this.replaceNode(originalValue);
+
             } else {
                 console.error("The group node already exists!", group.tag);
             }

--- a/src/utils/Splinter.js
+++ b/src/utils/Splinter.js
@@ -479,7 +479,7 @@ class Splinter {
         if (typeof a === 'string') {
             const node = this.nodes.get(a);
             if (node) {
-                newNode = { value: node?.attributes.label[0], link: node?.id };
+                newNode = { value: a, link: node?.id };
             } else if (a.startsWith('http')) {
                 newNode = { value: a, link: a };
             }
@@ -552,7 +552,7 @@ class Splinter {
             ) {
                 let node = this.nodes.get(a);
                 if (node) {
-                    updateTechniques.push({ value: node?.attributes.label[0], link: node?.id });
+                    updateTechniques.push({ value: node?.attributes?.label?.[0], link: node?.id });
                 } else {
                     updateTechniques.push({ value: a, link: a });
                 }


### PR DESCRIPTION
## Summary
- ensure subject group attributes keep their original identifiers while exposing label/link objects for chips
- rebuild group counting to read label from link-aware attributes and enrich subject/sample metadata after link calculation
- linkify dataset metadata and protocol techniques when they reference ontology terms or HTTP URLs

## Testing
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a099b858848321938e06b555ebe953