### PR TITLE
Handle sample-to-sample derivation in graph model

### DIFF
--- a/src/components/DatasetsListViewer/DatasetsListSplinter.js
+++ b/src/components/DatasetsListViewer/DatasetsListSplinter.js
@@ -362,28 +362,67 @@ class Splinter {
             }
         });
 
-        this.nodes.forEach((value, key) => {
-            if (value.attributes !== undefined && value.attributes.hasFolderAboutIt !== undefined) {
-                const children = this.tree_parents_map.get(this.tree_map.get(value.attributes.hasFolderAboutIt[0])?.remote_id);
-                children?.forEach(child => {
-                    const sampleNode = sampleFolderMap.get(child.remote_id);
-                    if (sampleNode) {
-                        sampleNode.level = value.level + 1;
-                        sampleNode.parent = value;
-                        this.nodes.set(sampleNode.id, sampleNode);
-                        this.forced_edges.push({ source: value.id, target: sampleNode.id });
-                        const sampleChildren = this.tree_parents_map.get(child.remote_id);
-                        sampleChildren?.forEach(grandChild => {
-                            !this.filterNode(grandChild) && this.linkToNode(grandChild, sampleNode);
+        this.nodes.forEach(value => {
+            if (value.attributes?.hasFolderAboutIt) {
+                value.attributes.hasFolderAboutIt.forEach(fid => {
+                    const jsonNode = this.tree_map.get(fid);
+                    const splitName = jsonNode?.dataset_relative_path?.split('/') || [];
+                    const lastPath = splitName[splitName.length - 1];
+                    const localId = value.attributes?.localId?.[0];
+
+                    if (value.type === rdfTypes.Sample.key && localId && (lastPath === localId || jsonNode.basename === localId)) {
+                        const newFolder = this.buildFolder(jsonNode, splitName[0]);
+                        newFolder.remote_id = jsonNode.basename + '_' + splitName[0];
+                        newFolder.uri_api = newFolder.remote_id;
+                        this.linkToNode(newFolder, value);
+
+                        const children = this.tree_parents_map.get(jsonNode.remote_id);
+                        children?.forEach(child => {
+                            const sampleNode = sampleFolderMap.get(child.remote_id);
+                            if (sampleNode) {
+                                sampleNode.level = value.level + 1;
+                                sampleNode.parent = value;
+                                this.nodes.set(sampleNode.id, sampleNode);
+                                this.forced_edges.push({ source: value.id, target: sampleNode.id });
+                                const sampleChildren = this.tree_parents_map.get(child.remote_id);
+                                sampleChildren?.forEach(grandChild => {
+                                    !this.filterNode(grandChild) && this.linkToNode(grandChild, sampleNode);
+                                });
+                            } else {
+                                !this.filterNode(child) && this.linkToNode(child, this.nodes.get(newFolder.remote_id));
+                            }
                         });
                     } else {
-                        !this.filterNode(child) && this.linkToNode(child, value);
+                        const children = this.tree_parents_map.get(jsonNode.remote_id);
+                        children?.forEach(child => {
+                            const sampleNode = sampleFolderMap.get(child.remote_id);
+                            if (sampleNode) {
+                                sampleNode.level = value.level + 1;
+                                sampleNode.parent = value;
+                                this.nodes.set(sampleNode.id, sampleNode);
+                                this.forced_edges.push({ source: value.id, target: sampleNode.id });
+                                const sampleChildren = this.tree_parents_map.get(child.remote_id);
+                                sampleChildren?.forEach(grandChild => {
+                                    !this.filterNode(grandChild) && this.linkToNode(grandChild, sampleNode);
+                                });
+                            } else {
+                                !this.filterNode(child) && this.linkToNode(child, value);
+                            }
+                        });
                     }
                 });
             }
         });
     }
 
+
+    buildFolder(item, newName) {
+        const copied = { ...item };
+        copied.parent_id = copied.remote_id;
+        copied.uri_api = copied.remote_id;
+        copied.basename = newName;
+        return copied;
+    }
 
     linkToNode(node, parent) {
         let level = parent.level;

--- a/src/components/DatasetsListViewer/DatasetsListSplinter.js
+++ b/src/components/DatasetsListViewer/DatasetsListSplinter.js
@@ -496,6 +496,33 @@ class Splinter {
 
             return value;
         })
+
+        this.fix_links();
+    }
+
+    fix_links() {
+        this.forced_nodes.forEach(node => {
+            if (node.type === rdfTypes.Sample.key) {
+                const subjectParent = node.attributes.derivedFromSubject?.[0];
+                const sampleParent = node.attributes.derivedFromSample?.[0];
+
+                if (sampleParent && subjectParent) {
+                    this.forced_edges = this.forced_edges.filter(link => !(link.source === subjectParent && link.target === node.id));
+                    delete node.attributes.derivedFromSubject;
+                }
+
+                const sourceId = sampleParent || subjectParent;
+                if (sourceId) {
+                    const source = this.nodes.get(sourceId);
+                    if (source) {
+                        node.level = source.level + 1;
+                        node.parent = source;
+                        this.forced_edges = this.forced_edges.filter(link => !(link.source === sourceId && link.target === node.id));
+                        this.forced_edges.push({ source: sourceId, target: node.id });
+                    }
+                }
+            }
+        });
     }
 
     build_leaf(node, parent) {

--- a/src/components/DatasetsListViewer/DatasetsListSplinter.js
+++ b/src/components/DatasetsListViewer/DatasetsListSplinter.js
@@ -354,11 +354,31 @@ class Splinter {
         const datasetNode = this.nodes.get(this.root_id) || Array.from(this.nodes.values())[0];
         this.basePublishedURI = datasetNode?.attributes?.hasUriPublished?.[0] || datasetNode?.attributes?.hasUriHuman?.[0] || "";
         this.baseHumanURI = datasetNode?.attributes?.hasUriHuman?.[0] || "";
+
+        const sampleFolderMap = new Map();
+        this.nodes.forEach(n => {
+            if (n.type === rdfTypes.Sample.key && n.attributes?.hasFolderAboutIt !== undefined) {
+                n.attributes.hasFolderAboutIt.forEach(fid => sampleFolderMap.set(fid, n));
+            }
+        });
+
         this.nodes.forEach((value, key) => {
             if (value.attributes !== undefined && value.attributes.hasFolderAboutIt !== undefined) {
                 const children = this.tree_parents_map.get(this.tree_map.get(value.attributes.hasFolderAboutIt[0])?.remote_id);
                 children?.forEach(child => {
-                    !this.filterNode(child) && this.linkToNode(child, value);
+                    const sampleNode = sampleFolderMap.get(child.remote_id);
+                    if (sampleNode) {
+                        sampleNode.level = value.level + 1;
+                        sampleNode.parent = value;
+                        this.nodes.set(sampleNode.id, sampleNode);
+                        this.forced_edges.push({ source: value.id, target: sampleNode.id });
+                        const sampleChildren = this.tree_parents_map.get(child.remote_id);
+                        sampleChildren?.forEach(grandChild => {
+                            !this.filterNode(grandChild) && this.linkToNode(grandChild, sampleNode);
+                        });
+                    } else {
+                        !this.filterNode(child) && this.linkToNode(child, value);
+                    }
                 });
             }
         });
@@ -368,10 +388,11 @@ class Splinter {
     linkToNode(node, parent) {
         let level = parent.level;
         if (parent.type === rdfTypes.Sample.key) {
-            if (parent.attributes.derivedFrom !== undefined) {
-                level = this.nodes.get(parent.attributes.derivedFrom[0]).level + 1;
-            } else if (parent.attributes.wasDerivedFromSubject !== undefined) {
-                level = this.nodes.get(parent.attributes.wasDerivedFromSubject[0]).level + 1;
+            const parentSource = parent.attributes.derivedFromSample?.length ?
+                parent.attributes.derivedFromSample[0] :
+                parent.attributes.derivedFromSubject?.[0];
+            if (parentSource !== undefined) {
+                level = this.nodes.get(parentSource).level + 1;
             }
         }
         parent.children_counter++;

--- a/src/components/NodeDetailView/Details/SubjectDetails.js
+++ b/src/components/NodeDetailView/Details/SubjectDetails.js
@@ -28,7 +28,7 @@ const SubjectDetails = (props) => {
 
         return n;
     }
-
+    
     return (
         <Box id={node?.graph_node?.id + detailsLabel}>
             <Divider />
@@ -39,10 +39,19 @@ const SubjectDetails = (props) => {
                     if ( property.visible ){
                         const propValue = node.graph_node.attributes[property.property]?.[0];
                         if ( property.isGroup ){
-                            return (<Box className="tab-content-row">
-                                        <Typography component="label">{property.label}</Typography>
-                                        <SimpleLinkedChip chips={[{ value : node.graph_node.attributes[property.property]}]} node={getGroupNode(node.graph_node.attributes[property.property]?.[0], node)} />
-                                    </Box>)
+                            const rawValue = node.graph_node.attributes[property.property];
+                            const propValue = Array.isArray(rawValue) ? rawValue[0] : rawValue;
+                            const normalizedArray = Array.isArray(rawValue) ? rawValue : [rawValue];
+  
+                            return (
+                                <Box className="tab-content-row">
+                                <Typography component="label">{property.label}</Typography>
+                                <SimpleLinkedChip
+                                    chips={[{ value: normalizedArray[0] }]}
+                                    node={getGroupNode(normalizedArray[0], node)}
+                                />
+                                </Box>
+                            );
                         }
 
                         else if ( isValidUrl(propValue) ){

--- a/src/components/NodeDetailView/Details/Views/SimpleLinkedChip.js
+++ b/src/components/NodeDetailView/Details/Views/SimpleLinkedChip.js
@@ -35,12 +35,12 @@ const SimpleChip = ({ chips, node }) => {
   return (
     <Box className="chip-overflow noscrollbar">
       {chips?.map((chip, index) => {
-        const item = typeof chip === 'object' ? chip : { value: chip };
+        const item = typeof chip === 'object' ? chip : { value: chip.value };
         const key = `${item.value}_${index}`;
         return (
           <Chip
             key={key}
-            label={item.value}
+            label={item.value?.value ? item.value.value : item.value}
             onClick={() => handleClick(item, node)}
             onContextMenu={(e) => handleContextMenu(e, item)}
           />

--- a/src/components/NodeDetailView/Details/Views/SimpleLinkedChip.js
+++ b/src/components/NodeDetailView/Details/Views/SimpleLinkedChip.js
@@ -1,45 +1,53 @@
 import React from "react";
-import {
-  Box,
-  Chip
-} from "@material-ui/core";
+import { Box, Chip } from "@material-ui/core";
 import { useDispatch } from 'react-redux';
 import { selectGroup } from '../../../../redux/actions';
 import { GRAPH_SOURCE } from '../../../../constants';
 
-
-const SimpleChip = ({chips, node}) => {
+const SimpleChip = ({ chips, node }) => {
   const dispatch = useDispatch();
 
-  const handleClick = (item, node) => {
-    if ( item.link ){
-      window.open(item.link, '_blank')
-    } else if ( item.value ) {
-      let urlCheck = new RegExp("([a-zA-Z0-9]+://)?([a-zA-Z0-9_]+:[a-zA-Z0-9_]+@)?([a-zA-Z0-9.-]+\\.[A-Za-z]{2,4})(:[0-9]+)?(/.*)?");
-      if(urlCheck.test(item.value)) {
-        window.open(item.value, '_blank')
-      } else {
-        if ( node ) {
-          dispatch(selectGroup({
-            dataset_id: node.dataset_id,
-            graph_node: node?.id,
-            tree_node: node?.tree_reference?.id,
-            source: GRAPH_SOURCE
-          }));
-        }
-      }
+  const handleClick = (item, groupNode) => {
+    if (item.link) {
+      window.open(item.link, '_blank');
+      return;
     }
-  }
+    const value = item.value;
+    const urlCheck = new RegExp("([a-zA-Z0-9]+://)?([a-zA-Z0-9_]+:[a-zA-Z0-9_]+@)?([a-zA-Z0-9.-]+\\.[A-Za-z]{2,4})(:[0-9]+)?(/.*)?");
+    if (urlCheck.test(value)) {
+      window.open(value, '_blank');
+    } else if (groupNode) {
+      dispatch(selectGroup({
+        dataset_id: groupNode.dataset_id,
+        graph_node: groupNode?.id,
+        tree_node: groupNode?.tree_reference?.id,
+        source: GRAPH_SOURCE
+      }));
+    }
+  };
+
+  const handleContextMenu = (e, item) => {
+    e.preventDefault();
+    const url = item.link || item.value;
+    navigator.clipboard.writeText(url);
+  };
 
   return (
     <Box className="chip-overflow noscrollbar">
-      { chips?.map((item, index) => ( node === undefined
-        ? item.link ? 
-        (<Chip label={item?.value} onClick={() => handleClick(item, null)}/>)
-        : (<Chip label={item?.value} />)
-        : (<Chip label={item?.value} onClick={() => handleClick(item, node)}/>)))
-      }
+      {chips?.map((chip, index) => {
+        const item = typeof chip === 'object' ? chip : { value: chip };
+        const key = `${item.value}_${index}`;
+        return (
+          <Chip
+            key={key}
+            label={item.value}
+            onClick={() => handleClick(item, node)}
+            onContextMenu={(e) => handleContextMenu(e, item)}
+          />
+        );
+      })}
     </Box>
-  )
-}
+  );
+};
+
 export default SimpleChip;

--- a/src/utils/GraphViewerHelper.js
+++ b/src/utils/GraphViewerHelper.js
@@ -73,10 +73,18 @@ export const paintNode = (node, ctx, hoverNode, selectedNode, nodeSelected, prev
       const nodeImageSize = [size * 2.4, size * 2.4];
       const hoverRectDimensions = [size * 4.2, size * 4.2];
       const hoverRectPosition = [node.x - hoverRectDimensions[0]/2, node.y - hoverRectDimensions[1]/2];
+
+      ctx.font = NODE_FONT;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'top';
+      let nodeName = Array.isArray(node.name) ? node.name[0] : node.name;
+      const textWidth = ctx.measureText(nodeName).width + 4;
+      const textHoverWidth = Math.max(textWidth, hoverRectDimensions[0]);
       const textHoverPosition = [
-        hoverRectPosition[0],
+        node.x - textHoverWidth / 2,
         hoverRectPosition[1] + hoverRectDimensions[1],
       ];
+      const textProps = [nodeName, node.x, textHoverPosition[1]];
       const hoverRectBorderRadius = 1;
       ctx.beginPath();
 
@@ -101,11 +109,6 @@ export const paintNode = (node, ctx, hoverNode, selectedNode, nodeSelected, prev
         );
       }
 
-      ctx.font = NODE_FONT;
-      ctx.textAlign = 'center';
-      ctx.textBaseline = 'top';
-      let nodeName = Array.isArray(node.name) ? node.name[0] : node.name;
-      const textProps = [nodeName, node.x, textHoverPosition[1]];
       if (node === hoverNode || node?.id === selectedNode?.id || node?.id === nodeSelected?.id ) {
         // image hover
         roundRect(
@@ -120,7 +123,7 @@ export const paintNode = (node, ctx, hoverNode, selectedNode, nodeSelected, prev
         roundRect(
           ctx,
           ...textHoverPosition,
-          hoverRectDimensions[0],
+          textHoverWidth,
           hoverRectDimensions[1] / 4,
           hoverRectBorderRadius,
           GRAPH_COLORS.textHoverRect
@@ -140,7 +143,7 @@ export const paintNode = (node, ctx, hoverNode, selectedNode, nodeSelected, prev
         roundRect(
             ctx,
             ...textHoverPosition,
-            hoverRectDimensions[0],
+            textHoverWidth,
             hoverRectDimensions[1] / 4,
             hoverRectBorderRadius,
             GRAPH_COLORS.textBGSeen

--- a/src/utils/GraphViewerHelper.js
+++ b/src/utils/GraphViewerHelper.js
@@ -104,12 +104,7 @@ export const paintNode = (node, ctx, hoverNode, selectedNode, nodeSelected, prev
       ctx.font = NODE_FONT;
       ctx.textAlign = 'center';
       ctx.textBaseline = 'top';
-      let nodeName = node.name;
-      if (nodeName.length > 10) {
-        nodeName = nodeName.substr(0, 9).concat('...');
-      } else if ( Array.isArray(nodeName) ){
-        nodeName = nodeName[0]?.substr(0, 9).concat('...');
-      }
+      let nodeName = Array.isArray(node.name) ? node.name[0] : node.name;
       const textProps = [nodeName, node.x, textHoverPosition[1]];
       if (node === hoverNode || node?.id === selectedNode?.id || node?.id === nodeSelected?.id ) {
         // image hover

--- a/src/utils/Splinter.js
+++ b/src/utils/Splinter.js
@@ -471,17 +471,24 @@ class Splinter {
         }
     }
 
-    replaceNode(a) {
+    replaceNode(a, originalValue = a) {
         if (a && typeof a === 'object') {
             return a;
         }
-        let newNode = { value: a };
+        let newNode = { value: a, link: originalValue };
         if (typeof a === 'string') {
-            const node = this.nodes.get(a);
-            if (node) {
-                newNode = { value: a, link: node?.id };
-            } else if (a.startsWith('http') || (!a.includes(' ') && a.includes(':'))) {
-                newNode = { value: a, link: a };
+            if (
+                a?.includes(rdfTypes.NCBITaxon.key) ||
+                a?.includes(rdfTypes.PATO.key) ||
+                a?.includes(rdfTypes.UBERON.key) ||
+                a?.includes(rdfTypes.RRID.key)
+            ) {
+                const node = this.nodes.get(a);
+                if (node) {
+                    newNode = { value: a, link: node?.id };
+                } else if (a.startsWith('http') || (!a.includes(' ') && a.includes(':'))) {
+                    newNode = { value: a, link: originalValue };
+                }
             }
         }
         return newNode;
@@ -610,7 +617,8 @@ class Splinter {
                         samples: 0,
                         subjects: 0,
                         publishedURI: "",
-                        dataset_id: this.dataset_id
+                        dataset_id: this.dataset_id,
+                        link : source?.id || parent?.link
                     };
                     let nodeF = this.factory.createNode(groupNode);
                     const img = new Image();
@@ -628,7 +636,7 @@ class Splinter {
                 }
 
                 // preserve the original identifier so chips can expose links
-                target_node.attributes[key][0] = this.replaceNode(originalValue);
+                target_node.attributes[key][0] = this.replaceNode(label, originalValue);
 
             } else {
                 console.error("The group node already exists!", group.tag);
@@ -1078,6 +1086,7 @@ class Splinter {
                         return;
                     }
 
+                    let newName = jsonNode.dataset_relative_path;
                     if (localId && (lastPath === localId || jsonNode.basename === localId)) {
                         let treeEntry = this.tree_map.get(jsonNode.uri_api);
                         if (treeEntry) {
@@ -1087,9 +1096,8 @@ class Splinter {
                             this.tree_map.set(jsonNode.remote_id, treeEntry);
                             this.tree_map.set(value.id, treeEntry);
                         }
+                        newName = splitName[0];
                     }
-
-                    let newName = jsonNode.dataset_relative_path;
 
                     let parentNode = value;
                     let newNode = this.buildFolder(jsonNode, newName, parentNode);
@@ -1101,29 +1109,20 @@ class Splinter {
                     }
 
 
-                    const children = this.tree_parents_map2.get(newNode.parent_id) || [];
-                    let sampleChildren = [];
+                    const children = this.tree_parents_map2.get(jsonNode.remote_id) || [];
                     let folderChildren = [];
-                    const parentTreeId = value.tree_reference?.uri_api || value.id;
+                    const parentTreeId = value.id;
                     children.forEach(child => {
                         const childIsSample = [...this.nodes.values()].some(n =>
                             n.type === rdfTypes.Sample.key &&
                             n.attributes?.hasFolderAboutIt?.includes(child.remote_id)
                         );
-                        if (childIsSample) {
-                            child.parent_id = parentTreeId;
-                            sampleChildren.push(child);
-                        } else {
+                        if (!childIsSample) {
                             child.parent_id = newNode.uri_api;
                             child.collapsed = true;
                             folderChildren.push(child);
                         }
                     });
-
-                    if (sampleChildren.length > 0) {
-                        const existing = this.tree_parents_map2.get(parentTreeId) || [];
-                        this.tree_parents_map2.set(parentTreeId, [...existing, ...sampleChildren]);
-                    }
 
                     if (!this.filterNode(newNode) && (this.nodes.get(newNode.remote_id)) === undefined) {
                         this.linkToNode(newNode, parentNode);
@@ -1132,7 +1131,7 @@ class Splinter {
                     const existingFolderChildren = this.tree_parents_map2.get(newNode.uri_api) || [];
                     const updatedChildren = folderChildren === undefined ? existingFolderChildren : [...existingFolderChildren, ...folderChildren];
                     this.tree_parents_map2.set(newNode.uri_api, updatedChildren);
-                    this.tree_parents_map2.delete(newNode.parent_id);
+                    this.tree_parents_map2.delete(jsonNode.remote_id);
                     folderChildren.forEach(child => {
                         if (!this.filterNode(child)) {
                             this.linkToNode(child, this.nodes.get(newNode.remote_id));
@@ -1141,7 +1140,7 @@ class Splinter {
                     const existingFolderChildrenMain = this.tree_parents_map.get(newNode.uri_api) || [];
                     const updatedChildrenMain = folderChildren === undefined ? existingFolderChildrenMain : [...existingFolderChildrenMain, ...folderChildren];
                     this.tree_parents_map.set(newNode.uri_api, updatedChildrenMain);
-                    this.tree_parents_map.delete(newNode.parent_id);
+                    this.tree_parents_map.delete(jsonNode.remote_id);
 
                     this.tree_map.set(newNode.uri_api, newNode);
 

--- a/src/utils/Splinter.js
+++ b/src/utils/Splinter.js
@@ -472,13 +472,16 @@ class Splinter {
     }
 
     replaceNode(a) {
-        let newNode = { "value": a };
+        if (a && typeof a === 'object') {
+            return a;
+        }
+        let newNode = { value: a };
         if (typeof a === 'string') {
             const node = this.nodes.get(a);
             if (node) {
-                newNode = { "value": node?.attributes.label[0], "link": node?.id };
+                newNode = { value: node?.attributes.label[0], link: node?.id };
             } else if (a.startsWith('http')) {
-                newNode = { "value": a, "link": a };
+                newNode = { value: a, link: a };
             }
         }
         return newNode;

--- a/src/utils/Splinter.js
+++ b/src/utils/Splinter.js
@@ -480,7 +480,7 @@ class Splinter {
             const node = this.nodes.get(a);
             if (node) {
                 newNode = { value: a, link: node?.id };
-            } else if (a.startsWith('http')) {
+            } else if (a.startsWith('http') || (!a.includes(' ') && a.includes(':'))) {
                 newNode = { value: a, link: a };
             }
         }

--- a/src/utils/Splinter.js
+++ b/src/utils/Splinter.js
@@ -837,6 +837,7 @@ class Splinter {
 
                 if (sampleParent && subjectParent) {
                     this.edges = this.edges.filter(link => !(link.source === node.id && link.target === subjectParent));
+                    this.forced_edges = this.forced_edges.filter(link => !(link.source === subjectParent && link.target === node.id));
                     delete node.attributes.derivedFromSubject;
                 }
 
@@ -848,6 +849,7 @@ class Splinter {
                         array[index].level = source.level + 1;
                         array[index].parent = source;
                         this.nodes.set(node.id, array[index]);
+                        this.forced_edges = this.forced_edges.filter(link => !(link.source === sourceId && link.target === node.id));
                         this.forced_edges.push({
                             source: sourceId,
                             target: node.id

--- a/src/utils/Splinter.js
+++ b/src/utils/Splinter.js
@@ -211,7 +211,9 @@ class Splinter {
                         if ( n?.attributes[key] ) {
                             let groupKeys = Object.keys(that.groups[key]);
                             groupKeys.forEach( groupKey => {
-                                if ( n?.attributes[key][0] === groupKey ) {
+                                const attrVal = n?.attributes[key][0];
+                                const attrName = typeof attrVal === 'object' ? attrVal.value : attrVal;
+                                if ( attrName === groupKey ) {
                                     const groupNodes = filteredNodes?.filter(n => n.name == groupKey);
                                     groupNodes?.forEach( groupNode => {
                                         if ( n?.id?.includes(groupNode.id) ) {
@@ -271,6 +273,21 @@ class Splinter {
             }
             return true;
         });
+
+        // After computing links, add link information to subject and sample attributes
+        this.nodes.forEach((n, k) => {
+            if (n.type === rdfTypes.Subject.key || n.type === rdfTypes.Sample.key) {
+                const attrs = n.attributes || {};
+                Object.keys(attrs).forEach(attr => {
+                    const arr = attrs[attr];
+                    if (Array.isArray(arr)) {
+                        attrs[attr] = arr.map(a => typeof a === 'object' ? a : that.replaceNode(a));
+                    }
+                });
+                this.nodes.set(k, n);
+            }
+        });
+
         return {
             nodes: filteredNodes,
             links: newCleanLinks,
@@ -455,14 +472,15 @@ class Splinter {
     }
 
     replaceNode(a) {
-        let newNode = {"value": a};
-        if( a?.includes(rdfTypes.NCBITaxon.key) || a?.includes(rdfTypes.PATO.key) || a?.includes(rdfTypes.UBERON.key) || a?.includes(rdfTypes.RRID.key) ) {
-            let node = this.nodes.get(a);
+        let newNode = { "value": a };
+        if (typeof a === 'string') {
+            const node = this.nodes.get(a);
             if (node) {
-                newNode = {"value": node?.attributes.label[0], "link": node?.id};
+                newNode = { "value": node?.attributes.label[0], "link": node?.id };
+            } else if (a.startsWith('http')) {
+                newNode = { "value": a, "link": a };
             }
         }
-
         return newNode;
     }
 
@@ -501,22 +519,42 @@ class Splinter {
         let updatedAbout = [];
         dataset_node.level = 1;
         let that = this;
-        dataset_node?.attributes?.isAbout?.forEach( (a) => {
-            updatedAbout.push(that.replaceNode(a));
+        dataset_node?.attributes?.isAbout?.forEach((a) => {
+            if (
+                typeof a === 'string' && (
+                    a.startsWith('http') ||
+                    a.includes(rdfTypes.NCBITaxon.key) ||
+                    a.includes(rdfTypes.PATO.key) ||
+                    a.includes(rdfTypes.UBERON.key) ||
+                    a.includes(rdfTypes.RRID.key)
+                )
+            ) {
+                updatedAbout.push(that.replaceNode(a));
+            } else {
+                updatedAbout.push({ value: a });
+            }
         });
         dataset_node.attributes.isAbout = updatedAbout;
 
         let updateTechniques = [];
-        dataset_node.attributes.protocolEmploysTechnique?.forEach( (a) => {
-            if( a.includes(rdfTypes.NCBITaxon.key) || a.includes(rdfTypes.PATO.key) || a.includes(rdfTypes.UBERON.key) ) {
+        dataset_node.attributes.protocolEmploysTechnique?.forEach((a) => {
+            if (
+                typeof a === 'string' && (
+                    a.startsWith('http') ||
+                    a.includes(rdfTypes.NCBITaxon.key) ||
+                    a.includes(rdfTypes.PATO.key) ||
+                    a.includes(rdfTypes.UBERON.key) ||
+                    a.includes(rdfTypes.RRID.key)
+                )
+            ) {
                 let node = this.nodes.get(a);
                 if (node) {
-                    updateTechniques.push({"value": node?.attributes.label[0], "link": node?.id});
+                    updateTechniques.push({ value: node?.attributes.label[0], link: node?.id });
                 } else {
-                    updateTechniques.push({"value": a});
+                    updateTechniques.push({ value: a, link: a });
                 }
             } else {
-                updateTechniques.push({"value": a});
+                updateTechniques.push({ value: a });
             }
         });
         dataset_node.attributes.protocolEmploysTechnique = updateTechniques;
@@ -539,34 +577,37 @@ class Splinter {
     organise_subjects(target_node, link, groups, k, type){
         let parent = this.nodes.get(k);
         let keys = Object.keys(config.groups.order);
-        keys.forEach( key => {
+        keys.forEach(key => {
             let group = config.groups.order[key];
-            if ( target_node.attributes[key]?.[0] ) {
-                let source = this.nodes.get(target_node.attributes[key]?.[0]);
-                if ( source !== undefined ) {
-                    target_node.attributes[key][0] = source.attributes.label[0];
-                }
-                
-                const groupID = parent.id + "_" + target_node.attributes[key]?.[0].replace(/\s/g, "");
-                if ( this.nodes.get(groupID) === undefined ) {
-                    let name = target_node.attributes[key]?.[0];
+            if (target_node.attributes[key]?.[0]) {
+                // attributes may already be objects from previous passes
+                const raw = target_node.attributes[key][0];
+                const originalValue = typeof raw === "object" ? raw.value : raw;
 
+                let source = this.nodes.get(originalValue);
+                let label = originalValue;
+                if (source !== undefined) {
+                    label = source.attributes.label[0];
+                }
+
+                const groupID = parent.id + "_" + ("" + label).replace(/\s/g, "");
+                if (this.nodes.get(groupID) === undefined) {
                     const groupNode = {
                         id: groupID,
-                        name: name,
+                        name: label,
                         type: typesModel.NamedIndividual.group.type,
                         properties: key,
-                        parent : parent,
+                        parent: parent,
                         proxies: [],
                         level: parent.level + 1,
                         tree_reference: null,
                         children_counter: 0,
-                        collapsed : false,
-                        childLinks : [],
-                        samples : 0, 
-                        subjects : 0,
-                        publishedURI : "",
-                        dataset_id : this.dataset_id
+                        collapsed: false,
+                        childLinks: [],
+                        samples: 0,
+                        subjects: 0,
+                        publishedURI: "",
+                        dataset_id: this.dataset_id
                     };
                     let nodeF = this.factory.createNode(groupNode);
                     const img = new Image();
@@ -577,11 +618,15 @@ class Splinter {
                         source: parent.id,
                         target: nodeF.id
                     });
-                    this.groups[key] ? this.groups[key][nodeF.name] = nodeF :  this.groups[key] = {[nodeF.name] : nodeF};
+                    this.groups[key] ? this.groups[key][nodeF.name] = nodeF : this.groups[key] = {[nodeF.name]: nodeF};
                     parent = groupNode;
                 } else {
                     parent = this.nodes.get(groupID);
                 }
+
+                // preserve the original identifier so chips can expose links
+                target_node.attributes[key][0] = this.replaceNode(originalValue);
+
             } else {
                 console.error("The group node already exists!", group.tag);
             }

--- a/src/utils/Splinter.js
+++ b/src/utils/Splinter.js
@@ -774,9 +774,21 @@ class Splinter {
                 target_node.parent = protocols;
                 this.nodes.set(target_node.id, target_node);
             } else if (link.source === id && target_node.type === rdfTypes.Sample.key ) {
-                link.source = target_node.attributes.derivedFrom[0];
-                target_node.level = subjects.level + 2;
-                target_node.parent = this.nodes.get(target_node.attributes.derivedFrom[0]);
+                const sourceId = target_node.attributes.derivedFromSample?.length ?
+                    target_node.attributes.derivedFromSample[0] :
+                    target_node.attributes.derivedFromSubject?.[0];
+                if (sourceId) {
+                    link.source = sourceId;
+                }
+                const parentSample = target_node.attributes.derivedFromSample?.[0] ?
+                    this.nodes.get(target_node.attributes.derivedFromSample[0]) : undefined;
+                if (parentSample) {
+                    target_node.level = parentSample.level + 1;
+                    target_node.parent = parentSample;
+                } else {
+                    target_node.level = subjects.level + 2;
+                    target_node.parent = this.nodes.get(subject_key);
+                }
                 this.nodes.set(target_node.id, target_node);
             } else if (link.source === id && target_node.type === rdfTypes.Site.key ) {
                 link.source = target_node.attributes.onSample[0];
@@ -820,31 +832,32 @@ class Splinter {
             }
             
             if (node.type === rdfTypes.Sample.key) {
-                if (node.attributes.derivedFrom !== undefined) {
-                    let source = this.nodes.get(node.attributes.derivedFrom[0]);
+                const subjectParent = node.attributes.derivedFromSubject?.[0];
+                const sampleParent = node.attributes.derivedFromSample?.[0];
+
+                if (sampleParent && subjectParent) {
+                    this.edges = this.edges.filter(link => !(link.source === node.id && link.target === subjectParent));
+                    delete node.attributes.derivedFromSubject;
+                }
+
+                const sourceId = sampleParent || subjectParent;
+                if (sourceId !== undefined) {
+                    let source = this.nodes.get(sourceId);
                     if ( source !== undefined ) {
                         source.children_counter++
                         array[index].level = source.level + 1;
+                        array[index].parent = source;
+                        this.nodes.set(node.id, array[index]);
                         this.forced_edges.push({
-                            source: node.attributes.derivedFrom[0],
-                            target: node.id
-                        });
-                    }
-                } else if (node.attributes.wasDerivedFromSubject !== undefined) {
-                    let source = this.nodes.get(node.attributes.wasDerivedFromSubject[0]);
-                    if ( source !== undefined ) {
-                        source.children_counter++
-                        array[index].level = source.level + 1;
-                        this.forced_edges.push({
-                            source: node.attributes.wasDerivedFromSubject[0],
+                            source: sourceId,
                             target: node.id
                         });
                     }
                 }
 
                 if (node.attributes?.hasFolderAboutIt !== undefined) {
-                    node.attributes.hasFolderAboutIt = 
-                        [basePublishedURI + 
+                    node.attributes.hasFolderAboutIt =
+                        [basePublishedURI +
                         "?datasetDetailsTab=files&path=files/" +
                         node.tree_reference?.dataset_relative_path];
                 }
@@ -1043,10 +1056,28 @@ class Splinter {
                     const localId = value.attributes?.localId?.[0];
                     const proxyTarget = this.proxies_map.get(jsonNode.remote_id);
 
-                    // Skip if this folder represents the same Subject/Sample node
-                    if ((proxyTarget && proxyTarget === value.id) ||
-                        (localId && lastPath === localId) ||
-                        (localId && jsonNode.basename === localId)) {
+                    if (value.type === rdfTypes.Subject.key && localId && (lastPath === localId || jsonNode.basename === localId)) {
+                        const children = this.tree_parents_map2.get(jsonNode.remote_id) || [];
+                        children.forEach(child => {
+                            const childIsSample = [...this.nodes.values()].some(n =>
+                                n.type === rdfTypes.Sample.key &&
+                                n.attributes?.hasFolderAboutIt?.includes(child.remote_id)
+                            );
+                            child.parent_id = value.id;
+                            if (childIsSample) {
+                                const existing = this.tree_parents_map2.get(value.id) || [];
+                                this.tree_parents_map2.set(value.id, [...existing, child]);
+                            } else if (!this.filterNode(child)) {
+                                this.linkToNode(child, value);
+                            }
+                        });
+                        this.tree_parents_map2.delete(jsonNode.remote_id);
+                        this.tree_parents_map.delete(jsonNode.remote_id);
+                        return;
+                    }
+
+                    // Skip if this folder already proxies to the current node
+                    if (proxyTarget && proxyTarget === value.id) {
                         // Make sure the tree node references the existing graph node
                         let treeEntry = this.tree_map.get(jsonNode.uri_api);
                         if (treeEntry) {
@@ -1065,13 +1096,24 @@ class Splinter {
                         return;
                     }
 
+                    if (localId && (lastPath === localId || jsonNode.basename === localId)) {
+                        let treeEntry = this.tree_map.get(jsonNode.uri_api);
+                        if (treeEntry) {
+                            treeEntry.graph_reference = value;
+                            value.tree_reference = treeEntry;
+                            this.tree_map.set(jsonNode.uri_api, treeEntry);
+                            this.tree_map.set(jsonNode.remote_id, treeEntry);
+                            this.tree_map.set(value.id, treeEntry);
+                        }
+                    }
+
                     let newName = jsonNode.basename;
                     if ( value.type === rdfTypes.Subject.key && localId == lastPath ) {
                         newName = splitName[0]
                     }
 
                     if ( value.type === rdfTypes.Sample.key && localId == lastPath ) {
-                        newName = splitName[0] + "/" + newName
+                        newName = splitName[0]
                     }
 
                     if ( value.type === rdfTypes.Performance.key && localId == lastPath ) {
@@ -1092,34 +1134,42 @@ class Splinter {
                     }
 
 
-                    let folderChildren = this.tree_parents_map2.get(newNode.parent_id)?.map(child => {
-                        child.parent_id = newNode.uri_api
-                        child.collapsed = true;
-                        return child;
+                    const children = this.tree_parents_map2.get(newNode.parent_id) || [];
+                    let sampleChildren = [];
+                    let folderChildren = [];
+                    children.forEach(child => {
+                        const childIsSample = [...this.nodes.values()].some(n =>
+                            n.type === rdfTypes.Sample.key &&
+                            n.attributes?.hasFolderAboutIt?.includes(child.remote_id)
+                        );
+                        if (childIsSample) {
+                            child.parent_id = value.id;
+                            sampleChildren.push(child);
+                        } else {
+                            child.parent_id = newNode.uri_api;
+                            child.collapsed = true;
+                            folderChildren.push(child);
+                        }
                     });
+
+                    if (sampleChildren.length > 0) {
+                        const existing = this.tree_parents_map2.get(value.id) || [];
+                        this.tree_parents_map2.set(value.id, [...existing, ...sampleChildren]);
+                    }
 
                     if (!this.filterNode(newNode) && (this.nodes.get(newNode.remote_id)) === undefined) {
                         this.linkToNode(newNode, parentNode);
                     }
 
-                    if (this.tree_parents_map2.get(newNode.uri_api) === undefined) {
-                        this.tree_parents_map2.set(newNode.uri_api, folderChildren);
-                        this.tree_parents_map2.delete(newNode.parent_id);
-                        folderChildren?.forEach(child => {
-                            if (!this.filterNode(child) ) {
-                                this.linkToNode(child, this.nodes.get(newNode.remote_id));
-                            }
-                        });
-                    } else {
-                        let tempChildren = folderChildren === undefined ? [...this.tree_parents_map2.get(newNode.uri_api)] : [...this.tree_parents_map2.get(newNode.uri_api), ...folderChildren];;
-                        this.tree_parents_map2.set(newNode.uri_api, tempChildren);
-                        this.tree_parents_map2.delete(newNode.parent_id);
-                        tempChildren?.forEach(child => {
-                            if (!this.filterNode(child) ) {
-                                this.linkToNode(child, this.nodes.get(newNode.remote_id));
-                            }
-                        });
-                    }
+                    const existingFolderChildren = this.tree_parents_map2.get(newNode.uri_api) || [];
+                    const updatedChildren = folderChildren === undefined ? existingFolderChildren : [...existingFolderChildren, ...folderChildren];
+                    this.tree_parents_map2.set(newNode.uri_api, updatedChildren);
+                    this.tree_parents_map2.delete(newNode.parent_id);
+                    folderChildren.forEach(child => {
+                        if (!this.filterNode(child)) {
+                            this.linkToNode(child, this.nodes.get(newNode.remote_id));
+                        }
+                    });
                 })
             }
         });
@@ -1137,12 +1187,18 @@ class Splinter {
     linkToNode(node, parent) {
         let level = parent?.level;
         if (parent?.type === rdfTypes.Sample.key) {
-            if (parent.attributes.derivedFrom !== undefined) {
-                level = this.nodes.get(parent.attributes.derivedFrom[0])?.level + 1;
+            const parentSource = parent.attributes.derivedFromSample?.length ?
+                parent.attributes.derivedFromSample[0] :
+                parent.attributes.derivedFromSubject?.[0];
+            if (parentSource !== undefined) {
+                level = this.nodes.get(parentSource)?.level + 1;
             }
         } else if (parent?.type === rdfTypes.Site.key) {
-            if (parent.attributes.derivedFrom !== undefined) {
-                level = this.nodes.get(parent.attributes.derivedFrom[0])?.level + 1;
+            const parentSource = parent.attributes.derivedFromSample?.length ?
+                parent.attributes.derivedFromSample[0] :
+                parent.attributes.derivedFromSubject?.[0];
+            if (parentSource !== undefined) {
+                level = this.nodes.get(parentSource)?.level + 1;
             }
         }
         const new_node = this.buildNodeFromJson(node, level);

--- a/src/utils/Splinter.js
+++ b/src/utils/Splinter.js
@@ -1170,6 +1170,22 @@ class Splinter {
                             this.linkToNode(child, this.nodes.get(newNode.remote_id));
                         }
                     });
+                    const existingFolderChildrenMain = this.tree_parents_map.get(newNode.uri_api) || [];
+                    const updatedChildrenMain = folderChildren === undefined ? existingFolderChildrenMain : [...existingFolderChildrenMain, ...folderChildren];
+                    this.tree_parents_map.set(newNode.uri_api, updatedChildrenMain);
+                    this.tree_parents_map.delete(newNode.parent_id);
+
+                    this.tree_map.set(newNode.uri_api, newNode);
+
+                    const parentChildren = this.tree_parents_map.get(parentNode.id) || [];
+                    this.tree_parents_map.set(parentNode.id, [...parentChildren, newNode]);
+                    const parentChildren2 = this.tree_parents_map2.get(parentNode.id) || [];
+                    this.tree_parents_map2.set(parentNode.id, [...parentChildren2, newNode]);
+
+                    const prevChildren = this.tree_parents_map.get(jsonNode.parent_id) || [];
+                    this.tree_parents_map.set(jsonNode.parent_id, prevChildren.filter(c => c.remote_id !== jsonNode.remote_id));
+                    const prevChildren2 = this.tree_parents_map2.get(jsonNode.parent_id) || [];
+                    this.tree_parents_map2.set(jsonNode.parent_id, prevChildren2.filter(c => c.remote_id !== jsonNode.remote_id));
                 })
             }
         });

--- a/src/utils/Splinter.js
+++ b/src/utils/Splinter.js
@@ -479,7 +479,7 @@ class Splinter {
         if (typeof a === 'string') {
             const node = this.nodes.get(a);
             if (node) {
-                newNode = { value: node?.attributes.label[0], link: node?.id };
+                newNode = { value: a, link: node?.id };
             } else if (a.startsWith('http')) {
                 newNode = { value: a, link: a };
             }
@@ -552,7 +552,7 @@ class Splinter {
             ) {
                 let node = this.nodes.get(a);
                 if (node) {
-                    updateTechniques.push({ value: node?.attributes.label[0], link: node?.id });
+                    updateTechniques.push({ value: node?.attributes?.label?.[0], link: node?.id });
                 } else {
                     updateTechniques.push({ value: a, link: a });
                 }

--- a/src/utils/Splinter.js
+++ b/src/utils/Splinter.js
@@ -1104,13 +1104,14 @@ class Splinter {
                     const children = this.tree_parents_map2.get(newNode.parent_id) || [];
                     let sampleChildren = [];
                     let folderChildren = [];
+                    const parentTreeId = value.tree_reference?.uri_api || value.id;
                     children.forEach(child => {
                         const childIsSample = [...this.nodes.values()].some(n =>
                             n.type === rdfTypes.Sample.key &&
                             n.attributes?.hasFolderAboutIt?.includes(child.remote_id)
                         );
                         if (childIsSample) {
-                            child.parent_id = value.id;
+                            child.parent_id = parentTreeId;
                             sampleChildren.push(child);
                         } else {
                             child.parent_id = newNode.uri_api;
@@ -1120,8 +1121,8 @@ class Splinter {
                     });
 
                     if (sampleChildren.length > 0) {
-                        const existing = this.tree_parents_map2.get(value.id) || [];
-                        this.tree_parents_map2.set(value.id, [...existing, ...sampleChildren]);
+                        const existing = this.tree_parents_map2.get(parentTreeId) || [];
+                        this.tree_parents_map2.set(parentTreeId, [...existing, ...sampleChildren]);
                     }
 
                     if (!this.filterNode(newNode) && (this.nodes.get(newNode.remote_id)) === undefined) {
@@ -1144,10 +1145,10 @@ class Splinter {
 
                     this.tree_map.set(newNode.uri_api, newNode);
 
-                    const parentChildren = this.tree_parents_map.get(parentNode.id) || [];
-                    this.tree_parents_map.set(parentNode.id, [...parentChildren, newNode]);
-                    const parentChildren2 = this.tree_parents_map2.get(parentNode.id) || [];
-                    this.tree_parents_map2.set(parentNode.id, [...parentChildren2, newNode]);
+                    const parentChildren = this.tree_parents_map.get(parentTreeId) || [];
+                    this.tree_parents_map.set(parentTreeId, [...parentChildren, newNode]);
+                    const parentChildren2 = this.tree_parents_map2.get(parentTreeId) || [];
+                    this.tree_parents_map2.set(parentTreeId, [...parentChildren2, newNode]);
 
                     const prevChildren = this.tree_parents_map.get(jsonNode.parent_id) || [];
                     this.tree_parents_map.set(jsonNode.parent_id, prevChildren.filter(c => c.remote_id !== jsonNode.remote_id));

--- a/src/utils/Splinter.js
+++ b/src/utils/Splinter.js
@@ -1058,26 +1058,6 @@ class Splinter {
                     const localId = value.attributes?.localId?.[0];
                     const proxyTarget = this.proxies_map.get(jsonNode.remote_id);
 
-                    if (value.type === rdfTypes.Subject.key && localId && (lastPath === localId || jsonNode.basename === localId)) {
-                        const children = this.tree_parents_map2.get(jsonNode.remote_id) || [];
-                        children.forEach(child => {
-                            const childIsSample = [...this.nodes.values()].some(n =>
-                                n.type === rdfTypes.Sample.key &&
-                                n.attributes?.hasFolderAboutIt?.includes(child.remote_id)
-                            );
-                            child.parent_id = value.id;
-                            if (childIsSample) {
-                                const existing = this.tree_parents_map2.get(value.id) || [];
-                                this.tree_parents_map2.set(value.id, [...existing, child]);
-                            } else if (!this.filterNode(child)) {
-                                this.linkToNode(child, value);
-                            }
-                        });
-                        this.tree_parents_map2.delete(jsonNode.remote_id);
-                        this.tree_parents_map.delete(jsonNode.remote_id);
-                        return;
-                    }
-
                     // Skip if this folder already proxies to the current node
                     if (proxyTarget && proxyTarget === value.id) {
                         // Make sure the tree node references the existing graph node
@@ -1109,28 +1089,13 @@ class Splinter {
                         }
                     }
 
-                    let newName = jsonNode.basename;
-                    if ( value.type === rdfTypes.Subject.key && localId == lastPath ) {
-                        newName = splitName[0]
-                    }
-
-                    if ( value.type === rdfTypes.Sample.key && localId == lastPath ) {
-                        newName = splitName[0]
-                    }
-
-                    if ( value.type === rdfTypes.Performance.key && localId == lastPath ) {
-                        newName = splitName[0] + "/" + newName
-                    }
-
-                    if ( value.type === rdfTypes.Site.key && localId ) {
-                        newName = splitName[0] + "/" + newName
-                    }
+                    let newName = jsonNode.dataset_relative_path;
 
                     let parentNode = value;
                     let newNode = this.buildFolder(jsonNode, newName, parentNode);
 
                     if ( value.type === rdfTypes.Sample.key) {
-                        newNode.remote_id = jsonNode.basename + '_' + newName;
+                        newNode.remote_id = jsonNode.basename + '_' + newName.replace(/\//g, '_');
                         newNode.uri_api = newNode.remote_id
                         // this.tree_parents_map2.delete(jsonNode.remote_id);
                     }

--- a/src/utils/graphModel.js
+++ b/src/utils/graphModel.js
@@ -826,8 +826,15 @@ export const rdfTypes = {
             {
                 "type": "TEMP",
                 "key": "wasDerivedFromSubject",
-                "property": "derivedFrom",
+                "property": "derivedFromSubject",
                 "label": "Derived from Subject",
+                "visible" : false
+            },
+            {
+                "type": "TEMP",
+                "key": "wasDerivedFromSample",
+                "property": "derivedFromSample",
+                "label": "Derived from Sample",
                 "visible" : false
             },
             {


### PR DESCRIPTION
## Summary
- prioritize sample-to-sample derivation links over subject links
- drop subject edges when sample derivations exist so nested samples render under their parent samples
- compute sample child levels using the chosen parent to keep primary/derivative folders grouped correctly
- reparent sample folders under their subject so hierarchy shows subject → sample → folder → files
- ignore subject-level folders that mirror the subject ID and reassign their children so primary/derivative folders live under each sample

## Testing
- `yarn install` *(fails: unable to access 'https://github.com/rodriguez-facundo/griddle.git/': CONNECT tunnel failed, response 403)*
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_68a66a240fd08321a57d6a5aa8d5147f