### PR TITLE
feat: include missing metadata properties

### DIFF
--- a/src/redux/initialState.js
+++ b/src/redux/initialState.js
@@ -3,8 +3,7 @@ import * as LayoutActions from '@metacell/geppetto-meta-client/common/layout/act
 import { rdfTypes } from "../utils/graphModel";
 import {TOGGLE_METADATA_ITEM_VISIBILITY, UPDATE_METADATA_ITEMS_ORDER} from "./actions";
 
-const savedMetadataModel = localStorage.getItem("metadata_model");
-const initialMetadataModel = savedMetadataModel ? JSON.parse(savedMetadataModel) : {
+const buildInitialMetadataModel = () => ({
     dataset: [...rdfTypes.Dataset.properties],
     subject: [...rdfTypes.Subject.properties],
     performance: [...rdfTypes.Performance.properties],
@@ -13,7 +12,30 @@ const initialMetadataModel = savedMetadataModel ? JSON.parse(savedMetadataModel)
     collection : [...rdfTypes.Collection.properties],
     group: [...rdfTypes.Group.properties],
     file: [...rdfTypes.File.properties]
+});
+
+const mergeMetadataModel = (base, saved) => {
+    const merged = { ...base };
+    Object.keys(saved || {}).forEach(key => {
+        const baseProps = base[key] ? [...base[key]] : [];
+        const savedProps = saved[key] ? [...saved[key]] : [];
+        savedProps.forEach(prop => {
+            const index = baseProps.findIndex(p => p.key === prop.key);
+            if (index !== -1) {
+                baseProps[index] = prop;
+            } else {
+                baseProps.push(prop);
+            }
+        });
+        merged[key] = baseProps;
+    });
+    return merged;
 };
+
+const savedMetadataModel = localStorage.getItem("metadata_model");
+const initialMetadataModel = savedMetadataModel
+    ? mergeMetadataModel(buildInitialMetadataModel(), JSON.parse(savedMetadataModel))
+    : buildInitialMetadataModel();
 export const sdsInitialState = {
     "sdsState": {
         datasets: [],
@@ -83,7 +105,9 @@ export default function sdsClientReducer(state = {}, action) {
                     tree: action.data.dataset.tree,
                     splinter: action.data.dataset.splinter
                 };
-                const ids = [...state.datasets, action.data.dataset.id]
+                const ids = [...state.datasets, action.data.dataset.id];
+                const refreshedModel = mergeMetadataModel(buildInitialMetadataModel(), state.metadata_model);
+                localStorage.setItem("metadata_model", JSON.stringify(refreshedModel));
                 return {
                     ...state,
                     datasets: ids,
@@ -91,7 +115,8 @@ export default function sdsClientReducer(state = {}, action) {
                         dataset_id: action.data.dataset.id,
                         graph_node: action.data.dataset.graph.nodes[0],
                         tree_node: action.data.dataset.graph.nodes[0].tree_reference,
-                    }
+                    },
+                    metadata_model: refreshedModel
                 };
             } else {
                 return state;

--- a/src/utils/nodesFactory.js
+++ b/src/utils/nodesFactory.js
@@ -18,6 +18,7 @@ function extractProperties(node, ttlTypes) {
         return;
     }
     for (const property of node.properties) {
+        let mapped = false;
         for (const type_property of rdfTypes[node.type].properties) {
             if (property.predicate === (ttlTypes[type_property.type]?.iri?.id + type_property.key)) {
                 if (node.attributes[type_property.property] !== undefined) {
@@ -26,9 +27,31 @@ function extractProperties(node, ttlTypes) {
                     node.attributes[type_property.property] = [];
                     node.attributes[type_property.property].push(property.value);
                 }
+                mapped = true;
+                break;
             }
         }
-        
+
+        if (!mapped) {
+            const prefixEntry = Object.entries(ttlTypes).find(([, value]) => property.predicate.startsWith(value?.iri?.id));
+            const prefix = prefixEntry ? prefixEntry[0] : undefined;
+            const key = prefixEntry ? property.predicate.replace(prefixEntry[1].iri.id, '') : property.predicate;
+            const label = key.replace(/_/g, ' ');
+            if (node.attributes[key] !== undefined) {
+                node.attributes[key].push(property.value);
+            } else {
+                node.attributes[key] = [property.value];
+            }
+            if (!rdfTypes[node.type].properties.find(p => p.property === key)) {
+                rdfTypes[node.type].properties.push({
+                    type: prefix,
+                    key: key,
+                    property: key,
+                    label: label.charAt(0).toUpperCase() + label.slice(1),
+                    visible: true,
+                });
+            }
+        }
     }
 
     if (node.additional_properties) {


### PR DESCRIPTION
## Summary
- capture unknown node properties as default text metadata
- rebuild metadata model with newly discovered fields when datasets load

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a748b07c108321a7559149b2d39a95