### PR TITLE
feat: configure folder icon colors for graph nodes

### DIFF
--- a/public/images/graph/folder-dark.svg
+++ b/public/images/graph/folder-dark.svg
@@ -1,0 +1,41 @@
+<svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M0 7.47C0 6.5497 0.365588 5.6671 1.01634 5.01634C1.66709 4.36559 2.5497 4 3.47 4H13.39C14.3886 3.99856 15.3607 4.32142 16.16 4.92L18.37 6.57C19.4628 7.38238 20.7884 7.82074 22.15 7.82H44.53C45.4503 7.82 46.3329 8.18559 46.9837 8.83634C47.6344 9.4871 48 10.3697 48 11.29V34C48 34.4552 47.9102 34.906 47.7357 35.3264C47.5612 35.7468 47.3054 36.1287 46.9831 36.4501C46.6607 36.7716 46.2781 37.0262 45.8572 37.1995C45.4362 37.3728 44.9852 37.4613 44.53 37.46H3.47C3.01479 37.4613 2.56379 37.3728 2.14284 37.1995C1.7219 37.0262 1.33929 36.7716 1.01694 36.4501C0.694593 36.1287 0.438836 35.7468 0.26433 35.3264C0.0898239 34.906 -1.90121e-06 34.4552 0 34L0 7.47Z" fill="url(#paint0_linear)"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M0 7.47C0 6.5497 0.365588 5.6671 1.01634 5.01634C1.66709 4.36559 2.5497 4 3.47 4H13.39C14.3886 3.99856 15.3607 4.32142 16.16 4.92L18.37 6.57C19.4628 7.38238 20.7884 7.82074 22.15 7.82H44.53C45.4503 7.82 46.3329 8.18559 46.9837 8.83634C47.6344 9.4871 48 10.3697 48 11.29V34C48 34.4552 47.9102 34.906 47.7357 35.3264C47.5612 35.7468 47.3054 36.1287 46.9831 36.4501C46.6607 36.7716 46.2781 37.0262 45.8572 37.1995C45.4362 37.3728 44.9852 37.4613 44.53 37.46H3.47C3.01479 37.4613 2.56379 37.3728 2.14284 37.1995C1.7219 37.0262 1.33929 36.7716 1.01694 36.4501C0.694593 36.1287 0.438836 35.7468 0.26433 35.3264C0.0898239 34.906 -1.90121e-06 34.4552 0 34L0 7.47Z" fill="url(#paint1_radial)"/>
+<path d="M44.53 10.7598H3.47C1.55357 10.7598 0 12.3133 0 14.2298V40.7098C0 42.6262 1.55357 44.1798 3.47 44.1798H44.53C46.4464 44.1798 48 42.6262 48 40.7098V14.2298C48 12.3133 46.4464 10.7598 44.53 10.7598Z" fill="url(#paint2_linear)"/>
+<path d="M44.53 10.7598H3.47C1.55357 10.7598 0 12.3133 0 14.2298V40.7098C0 42.6262 1.55357 44.1798 3.47 44.1798H44.53C46.4464 44.1798 48 42.6262 48 40.7098V14.2298C48 12.3133 46.4464 10.7598 44.53 10.7598Z" fill="url(#paint3_linear)"/>
+<g opacity="0.75">
+<path opacity="0.75" d="M48 39.1104H0V40.2704H48V39.1104Z" fill="url(#paint4_linear)"/>
+</g>
+<g opacity="0.75">
+<path opacity="0.75" d="M48 41.1602H0V42.3202H48V41.1602Z" fill="url(#paint5_linear)"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear" x1="24" y1="11.47" x2="24" y2="4.97001" gradientUnits="userSpaceOnUse">
+<stop stop-color="#636363"/>
+<stop offset="1" stop-color="#808080"/>
+</linearGradient>
+<radialGradient id="paint1_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(23.5464 4.9048) rotate(94.0856) scale(21.0535 87.5427)">
+<stop stop-color="#444444" stop-opacity="0.69"/>
+<stop offset="0.22" stop-color="#636363"/>
+<stop offset="1" stop-color="#808080"/>
+</radialGradient>
+<linearGradient id="paint2_linear" x1="24" y1="10.7498" x2="24" y2="45.0398" gradientUnits="userSpaceOnUse">
+<stop stop-color="#999999"/>
+<stop offset="0.42" stop-color="#808080"/>
+<stop offset="1" stop-color="#636363"/>
+</linearGradient>
+<linearGradient id="paint3_linear" x1="24" y1="10.7498" x2="24" y2="44.1798" gradientUnits="userSpaceOnUse">
+<stop stop-color="white" stop-opacity="0.3"/>
+<stop offset="0.02" stop-color="#555555" stop-opacity="0.29"/>
+<stop offset="1" stop-color="#333333" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint4_linear" x1="24" y1="39.1304" x2="24" y2="40.2604" gradientUnits="userSpaceOnUse">
+<stop stop-color="#808080"/>
+<stop offset="1" stop-color="#636363"/>
+</linearGradient>
+<linearGradient id="paint5_linear" x1="-8640" y1="-177.743" x2="-8640" y2="-179.066" gradientUnits="userSpaceOnUse">
+<stop stop-color="#808080"/>
+<stop offset="1" stop-color="#636363"/>
+</linearGradient>
+</defs>
+</svg>

--- a/public/images/graph/folder-grey.svg
+++ b/public/images/graph/folder-grey.svg
@@ -1,0 +1,41 @@
+<svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M0 7.47C0 6.5497 0.365588 5.6671 1.01634 5.01634C1.66709 4.36559 2.5497 4 3.47 4H13.39C14.3886 3.99856 15.3607 4.32142 16.16 4.92L18.37 6.57C19.4628 7.38238 20.7884 7.82074 22.15 7.82H44.53C45.4503 7.82 46.3329 8.18559 46.9837 8.83634C47.6344 9.4871 48 10.3697 48 11.29V34C48 34.4552 47.9102 34.906 47.7357 35.3264C47.5612 35.7468 47.3054 36.1287 46.9831 36.4501C46.6607 36.7716 46.2781 37.0262 45.8572 37.1995C45.4362 37.3728 44.9852 37.4613 44.53 37.46H3.47C3.01479 37.4613 2.56379 37.3728 2.14284 37.1995C1.7219 37.0262 1.33929 36.7716 1.01694 36.4501C0.694593 36.1287 0.438836 35.7468 0.26433 35.3264C0.0898239 34.906 -1.90121e-06 34.4552 0 34L0 7.47Z" fill="url(#paint0_linear)"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M0 7.47C0 6.5497 0.365588 5.6671 1.01634 5.01634C1.66709 4.36559 2.5497 4 3.47 4H13.39C14.3886 3.99856 15.3607 4.32142 16.16 4.92L18.37 6.57C19.4628 7.38238 20.7884 7.82074 22.15 7.82H44.53C45.4503 7.82 46.3329 8.18559 46.9837 8.83634C47.6344 9.4871 48 10.3697 48 11.29V34C48 34.4552 47.9102 34.906 47.7357 35.3264C47.5612 35.7468 47.3054 36.1287 46.9831 36.4501C46.6607 36.7716 46.2781 37.0262 45.8572 37.1995C45.4362 37.3728 44.9852 37.4613 44.53 37.46H3.47C3.01479 37.4613 2.56379 37.3728 2.14284 37.1995C1.7219 37.0262 1.33929 36.7716 1.01694 36.4501C0.694593 36.1287 0.438836 35.7468 0.26433 35.3264C0.0898239 34.906 -1.90121e-06 34.4552 0 34L0 7.47Z" fill="url(#paint1_radial)"/>
+<path d="M44.53 10.7598H3.47C1.55357 10.7598 0 12.3133 0 14.2298V40.7098C0 42.6262 1.55357 44.1798 3.47 44.1798H44.53C46.4464 44.1798 48 42.6262 48 40.7098V14.2298C48 12.3133 46.4464 10.7598 44.53 10.7598Z" fill="url(#paint2_linear)"/>
+<path d="M44.53 10.7598H3.47C1.55357 10.7598 0 12.3133 0 14.2298V40.7098C0 42.6262 1.55357 44.1798 3.47 44.1798H44.53C46.4464 44.1798 48 42.6262 48 40.7098V14.2298C48 12.3133 46.4464 10.7598 44.53 10.7598Z" fill="url(#paint3_linear)"/>
+<g opacity="0.75">
+<path opacity="0.75" d="M48 39.1104H0V40.2704H48V39.1104Z" fill="url(#paint4_linear)"/>
+</g>
+<g opacity="0.75">
+<path opacity="0.75" d="M48 41.1602H0V42.3202H48V41.1602Z" fill="url(#paint5_linear)"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear" x1="24" y1="11.47" x2="24" y2="4.97001" gradientUnits="userSpaceOnUse">
+<stop stop-color="#B3B3B3"/>
+<stop offset="1" stop-color="#D1D1D1"/>
+</linearGradient>
+<radialGradient id="paint1_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(23.5464 4.9048) rotate(94.0856) scale(21.0535 87.5427)">
+<stop stop-color="#808080" stop-opacity="0.69"/>
+<stop offset="0.22" stop-color="#B3B3B3"/>
+<stop offset="1" stop-color="#D1D1D1"/>
+</radialGradient>
+<linearGradient id="paint2_linear" x1="24" y1="10.7498" x2="24" y2="45.0398" gradientUnits="userSpaceOnUse">
+<stop stop-color="#E0E0E0"/>
+<stop offset="0.42" stop-color="#D1D1D1"/>
+<stop offset="1" stop-color="#B3B3B3"/>
+</linearGradient>
+<linearGradient id="paint3_linear" x1="24" y1="10.7498" x2="24" y2="44.1798" gradientUnits="userSpaceOnUse">
+<stop stop-color="white" stop-opacity="0.3"/>
+<stop offset="0.02" stop-color="#A0A0A0" stop-opacity="0.29"/>
+<stop offset="1" stop-color="#707070" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint4_linear" x1="24" y1="39.1304" x2="24" y2="40.2604" gradientUnits="userSpaceOnUse">
+<stop stop-color="#D1D1D1"/>
+<stop offset="1" stop-color="#B3B3B3"/>
+</linearGradient>
+<linearGradient id="paint5_linear" x1="-8640" y1="-177.743" x2="-8640" y2="-179.066" gradientUnits="userSpaceOnUse">
+<stop stop-color="#D1D1D1"/>
+<stop offset="1" stop-color="#B3B3B3"/>
+</linearGradient>
+</defs>
+</svg>

--- a/src/app/mainLayout.js
+++ b/src/app/mainLayout.js
@@ -29,7 +29,7 @@ const MainLayout = () => {
 
             myManager.model.visitNodes((node, level) => {
                 node.setEventListener("resize", (node) => {
-                    let visibleChild = myManager.model._activeTabSet._children.filter(element => 
+                    let visibleChild = myManager.model._activeTabSet._children.filter(element =>
                         element._visible
                     );
                     const event = new CustomEvent('nodeResized', {
@@ -39,14 +39,12 @@ const MainLayout = () => {
 
                 });
                 node.setEventListener("visibility", (node, data) => {
-                    let visibleChild = myManager.model._activeTabSet._children.filter(element => 
-                        !element._visible
-                    );
-                    const event = new CustomEvent('nodeVisible', {
-                        detail: visibleChild
-                    });
-                    document.dispatchEvent(event);
-
+                    if (data) {
+                        const event = new CustomEvent('nodeVisible', {
+                            detail: node
+                        });
+                        document.dispatchEvent(event);
+                    }
                 });
             });
 

--- a/src/components/GraphViewer/GraphViewer.js
+++ b/src/components/GraphViewer/GraphViewer.js
@@ -190,25 +190,30 @@ const GraphViewer = (props) => {
   },[selectedLayout]);
 
   useEffect(() => {
-    document.addEventListener("nodeVisible", (e) => {
-      let visibleNodes = e.detail;
-      let match = visibleNodes?.find( v => v?._attributes?.id === props.graph_id );
-      if ( match ) {
-        const updatedData = getPrunedTree(props.graph_id, selectedLayout.layout);
-        setData(updatedData);
-        setTimeout( timeout => {
-          setForce()
+    const handleVisible = (e) => {
+      const nodes = Array.isArray(e.detail) ? e.detail : [e.detail];
+      const match = nodes?.some(v => v?._attributes?.id === props.graph_id);
+      if (match) {
+        setTimeout(() => {
+          graphRef?.current?.ggv?.current?.refresh?.();
+          setForce();
           resetCamera();
-        },100)
+        }, 100);
       }
-    });
-    document.addEventListener("nodeResized", (e) => {
+    };
+    const handleResize = (e) => {
       let visibleNodes = e.detail;
-      let match = visibleNodes?.find( v => v?._attributes?.id === props.graph_id );
-      if ( match ) {
+      let match = visibleNodes?.find(v => v?._attributes?.id === props.graph_id);
+      if (match) {
         resetCamera();
       }
-    });
+    };
+    document.addEventListener("nodeVisible", handleVisible);
+    document.addEventListener("nodeResized", handleResize);
+    return () => {
+      document.removeEventListener("nodeVisible", handleVisible);
+      document.removeEventListener("nodeResized", handleResize);
+    };
   });
 
   useEffect(() => {

--- a/src/config/app.json
+++ b/src/config/app.json
@@ -4,10 +4,17 @@
     "issues_url":"https://github.com/MetaCell/sds-viewer/issues/new",
     "docs_url": "https://github.com/MetaCell/sds-viewer/blob/development/README.md",
     "available_datasets": "curation-export-published.ttl",
-    "groups" : { 
-        "order" : 
+    "graph": {
+        "folderIcons": {
+            "default": "./images/graph/folder-grey.svg",
+            "topLevel": "./images/graph/folder-dark.svg",
+            "special": "./images/graph/folder.svg"
+        }
+    },
+    "groups" : {
+        "order" :
         {
-            "animalSubjectIsOfSpecies" : { "tag" : "Subject Species", "icon" : "./images/graph/species.svg"}, 
+            "animalSubjectIsOfSpecies" : { "tag" : "Subject Species", "icon" : "./images/graph/species.svg"},
             "animalSubjectIsOfStrain" : { "tag" : "Subject Strain", "icon" : "./images/graph/strains.svg"},
             "hasBiologicalSex" : { "tag" : "Subject Sex", "icon" : "./images/graph/sex.svg"}, 
             "hasAgeCategory" : { "tag" : "Subject Age", "icon" : "./images/graph/age.svg"}

--- a/src/utils/Splinter.js
+++ b/src/utils/Splinter.js
@@ -484,6 +484,9 @@ class Splinter {
         this.nodes.forEach((value, key) => {
             value.type = this.get_type(value);
             const typedNode = this.factory.createNode(value, this.types);
+            if (typedNode.type === rdfTypes.Collection.key) {
+                typedNode.img.src = this.getFolderIcon(typedNode);
+            }
             if (typedNode.type !== rdfTypes.Unknown.key) {
                 this.nodes.set(key, typedNode);
             } else {
@@ -874,27 +877,42 @@ class Splinter {
                     }
                 }
 
+                // Extract weight value and unit
+                if (node.additional_properties["sparc:animalSubjectHasWeight"]) {
+                    let weightObj = node.additional_properties["sparc:animalSubjectHasWeight"];
+                    let weightValue = weightObj["rdf:value"] || "";
+                    let weightUnit = weightObj["TEMP:hasUnit"]?.["@id"]?.replace("unit:", "") || "";
+                    node.attributes.animalSubjectHasWeight = [`${weightValue} ${weightUnit}`];
+                }
+
+                // Extract age values (supports nested structures)
                 if (node.additional_properties["TEMP:hasAgeMax"]) {
                     let ageMaxObj = node.additional_properties["TEMP:hasAgeMax"];
-                    let ageValue = ageMaxObj["rdf:value"] || "";
-                    let ageUnit = ageMaxObj["TEMP:hasUnit"]?.["@id"]?.replace("unit:", "") || "";
+                    let ageValue = ageMaxObj["rdf:value"] || ageMaxObj["TEMP:right"]?.["rdf:value"] || "";
+                    let ageUnit =
+                        ageMaxObj["TEMP:hasUnit"]?.["@id"]?.replace("unit:", "") ||
+                        ageMaxObj["TEMP:right"]?.["TEMP:hasUnit"]?.["@id"]?.replace("unit:", "") || "";
                     node.attributes.hasAgeMax = [`${ageValue} ${ageUnit}`];
                 }
 
                 if (node.additional_properties["TEMP:hasAge"]) {
-                    let ageMaxObj = node.additional_properties["TEMP:hasAge"];
-                    let ageValue = ageMaxObj["rdf:value"] || "";
-                    let ageUnit = ageMaxObj["TEMP:hasUnit"]?.["@id"]?.replace("unit:", "") || "";
-                    node.attributes.hasAge =[`${ageValue} ${ageUnit}`];
+                    let ageObj = node.additional_properties["TEMP:hasAge"];
+                    let ageValue = ageObj["rdf:value"] || ageObj["TEMP:right"]?.["rdf:value"] || "";
+                    let ageUnit =
+                        ageObj["TEMP:hasUnit"]?.["@id"]?.replace("unit:", "") ||
+                        ageObj["TEMP:right"]?.["TEMP:hasUnit"]?.["@id"]?.replace("unit:", "") || "";
+                    node.attributes.hasAge = [`${ageValue} ${ageUnit}`];
                 }
-        
+
                 // Extract Age Min
                 if (node.additional_properties["TEMP:hasAgeMin"]) {
                     let ageMinObj = node.additional_properties["TEMP:hasAgeMin"];
-                    let ageValue = ageMinObj["rdf:value"] || "";
-                    let ageUnit = ageMinObj["TEMP:hasUnit"]?.["@id"]?.replace("unit:", "") || "";
+                    let ageValue = ageMinObj["rdf:value"] || ageMinObj["TEMP:right"]?.["rdf:value"] || "";
+                    let ageUnit =
+                        ageMinObj["TEMP:hasUnit"]?.["@id"]?.replace("unit:", "") ||
+                        ageMinObj["TEMP:right"]?.["TEMP:hasUnit"]?.["@id"]?.replace("unit:", "") || "";
                     node.attributes.hasAgeMin = [`${ageValue} ${ageUnit}`];
-                }                             
+                }
 
                 if (node.attributes?.hasDerivedInformationAsParticipant !== undefined && node.attributes?.participantInPerformanceOf !== undefined) {
                     let source = this.nodes.get(node.attributes.participantInPerformanceOf[0]);
@@ -1029,6 +1047,22 @@ class Splinter {
         return node.basename.includes(TMP_FILE)
     }
 
+    getFolderIcon(node) {
+        const defaultIcon = config.graph.folderIcons.default;
+        const topLevelIcon = config.graph.folderIcons.topLevel || defaultIcon;
+
+        const treePath = node.tree_reference?.dataset_relative_path;
+        const firstFromTree = treePath?.split('/')?.[0];
+        const isTopFromTree = firstFromTree && node.name === firstFromTree;
+        if (isTopFromTree) {
+            return topLevelIcon;
+        }
+
+        const relParts = node.attributes?.relativePath?.split('/') || [];
+        const firstAttr = relParts[0];
+        const fallbackTop = relParts.length === 1 && ["primary", "source", "derivative"].includes(firstAttr);
+        return fallbackTop ? topLevelIcon : defaultIcon;
+    }
 
     mergeData() {
         this.nodes.forEach((value, key) => {
@@ -1161,11 +1195,15 @@ class Splinter {
         });
         new_node.childLinks = [];
         if (!this.nodes.get(new_node.id)) {
-            this.nodes.set(new_node.id, this.factory.createNode(new_node));
+            let nodeF = this.factory.createNode(new_node);
+            if (nodeF.type === rdfTypes.Collection.key) {
+                nodeF.img.src = this.getFolderIcon(nodeF);
+            }
+            this.nodes.set(new_node.id, nodeF);
             var children = this.tree_parents_map2.get(node.remote_id);
             if (children?.length > 0) {
                 children.forEach(child => {
-                    !this.filterNode(child) && this.linkToNode(child, new_node);
+                    !this.filterNode(child) && this.linkToNode(child, nodeF);
                 });
             }
         }
@@ -1177,7 +1215,7 @@ class Splinter {
         if (node_id) {
             return undefined;
         }
-        const name = item.dataset_relative_path?.split('/')
+        const name = item.dataset_relative_path?.split('/');
         const new_node = {
             id: item.uri_api,
             level: level + 1,
@@ -1198,7 +1236,7 @@ class Splinter {
             tree_reference: null,
             children_counter: 0
         };
-        return this.factory.createNode(new_node, []);
+        return new_node;
     }
 
 

--- a/src/utils/graphModel.js
+++ b/src/utils/graphModel.js
@@ -1,3 +1,5 @@
+import config from '../config/app.json';
+
 export const type_key = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
 
 
@@ -52,7 +54,7 @@ export const rdfTypes = {
         ]
     },
     "Collection": {
-        "image": "./images/graph/folder.svg",
+        "image": config.graph.folderIcons.default,
         "key": "Collection",
         "properties": [
             {
@@ -451,7 +453,7 @@ export const rdfTypes = {
         ]
     },
     "Subject": {
-        "image": "./images/graph/folder.svg",
+        "image": config.graph.folderIcons.special,
         "key": "Subject",
         "properties": [
             {
@@ -626,7 +628,7 @@ export const rdfTypes = {
         ]
     },
     "Performance": {
-        "image": "./images/graph/folder.svg",
+        "image": config.graph.folderIcons.default,
         "key": "Performance",
         "properties": [
             {
@@ -774,7 +776,7 @@ export const rdfTypes = {
         ]
     },
     "Site": {
-        "image": "./images/graph/folder.svg",
+        "image": config.graph.folderIcons.special,
         "key": "Site",
         "properties": [
             {
@@ -799,7 +801,7 @@ export const rdfTypes = {
         "additional_properties" : []
     },
     "Sample": {
-        "image": "./images/graph/folder.svg",
+        "image": config.graph.folderIcons.special,
         "key": "Sample",
         "properties": [
             {


### PR DESCRIPTION
## Summary
- make folder/collection nodes use configurable grey icons
- keep Subject/Sample/Site nodes blue, with darker grey for top-level data folders
- expose folder icon paths in `app.json` and add grey icon assets
- detect top-level folders via dataset-relative paths instead of explicit list
- parse animal subject weight and age values from RDF into human-readable strings

## Testing
- `yarn install` *(fails: unable to access 'https://github.com/rodriguez-facundo/griddle.git/': CONNECT tunnel failed, response 403)*
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile)*


------
https://chatgpt.com/codex/tasks/task_b_68b9e3e4615c832192fc61cb12ec5dfe