### PR TITLE
Skip duplicate entity folders in Splinter

### DIFF
--- a/src/components/DatasetsListViewer/DatasetsListSplinter.js
+++ b/src/components/DatasetsListViewer/DatasetsListSplinter.js
@@ -374,6 +374,16 @@ class Splinter {
                 level = this.nodes.get(parent.attributes.wasDerivedFromSubject[0]).level + 1;
             }
         }
+        if (node.mimetype === "inode/directory") {
+            const entityTypes = [rdfTypes.Sample.key, rdfTypes.Subject.key, rdfTypes.Site.key];
+            const isEntityFolder = Array.from(this.nodes.values()).some(existing =>
+                entityTypes.includes(existing.type) && existing.name === node.basename
+            );
+            if (isEntityFolder) {
+                return;
+            }
+        }
+
         parent.children_counter++;
         const new_node = this.buildNodeFromJson(node, level);
         new_node.parent = parent;

--- a/src/components/NodeDetailView/Details/SubjectDetails.js
+++ b/src/components/NodeDetailView/Details/SubjectDetails.js
@@ -37,7 +37,30 @@ const SubjectDetails = (props) => {
 
                 {subjectPropertiesModel?.map( property => {
                     if ( property.visible ){
-                        const propValue = node.graph_node.attributes[property.property]?.[0];
+                        // Skip raw value/unit fields for age and weight
+                        if (["ageUnit", "ageValue", "ageBaseUnit", "ageBaseValue", "weightUnit", "weightValue"].includes(property.property)) {
+                            return <></>;
+                        }
+
+                        let propValue = node.graph_node.attributes[property.property]?.[0];
+
+                        // Combine age or weight values/units when split across attributes
+                        if (property.property === "hasAge" && !propValue) {
+                            const ageVal = node.graph_node.attributes?.ageValue?.[0];
+                            const ageUnit = node.graph_node.attributes?.ageUnit?.[0];
+                            if (ageVal !== undefined || ageUnit !== undefined) {
+                                propValue = `${ageVal ?? ""} ${ageUnit ?? ""}`.trim();
+                            }
+                        }
+
+                        if (property.property === "animalSubjectHasWeight" && !propValue) {
+                            const weightVal = node.graph_node.attributes?.weightValue?.[0];
+                            const weightUnit = node.graph_node.attributes?.weightUnit?.[0];
+                            if (weightVal !== undefined || weightUnit !== undefined) {
+                                propValue = `${weightVal ?? ""} ${weightUnit ?? ""}`.trim();
+                            }
+                        }
+
                         if ( property.isGroup ){
                             const rawValue = node.graph_node.attributes[property.property];
                             const propValue = Array.isArray(rawValue) ? rawValue[0] : rawValue;

--- a/src/utils/Splinter.js
+++ b/src/utils/Splinter.js
@@ -885,12 +885,15 @@ class Splinter {
                     return current;
                 };
 
-                // Extract weight value and unit
+                // Extract weight value and unit (prefer base units when available)
                 if (node.additional_properties["sparc:animalSubjectHasWeight"]) {
                     let weightObj = resolveNode(node.additional_properties["sparc:animalSubjectHasWeight"]);
+                    // Base units live under TEMP:asBaseUnits; fall back to declared unit
+                    let baseObj = resolveNode(weightObj?.["TEMP:asBaseUnits"]);
                     let weightValue = weightObj["rdf:value"]?.["@value"] || "";
-                    let unitObj = resolveNode(weightObj["TEMP:hasUnit"]);
-                    let weightUnit = unitObj?.["@id"]?.replace("unit:", "") || "";
+                    let unitFromBase = baseObj?.["TEMP:hasUnit"]?.["@id"];
+                    let unitFromObj = resolveNode(weightObj?.["TEMP:hasUnit"])?.["@id"];
+                    let weightUnit = (unitFromBase || unitFromObj || "").replace("unit:", "");
                     node.attributes.animalSubjectHasWeight = [`${weightValue} ${weightUnit}`];
                 }
 
@@ -1170,10 +1173,20 @@ class Splinter {
                 level = this.nodes.get(parentSource)?.level + 1;
             }
         }
-        const new_node = this.buildNodeFromJson(node, parent, level);
         if (!parent) {
             return;
         }
+        if (node.mimetype === "inode/directory") {
+            const entityTypes = [rdfTypes.Sample.key, rdfTypes.Subject.key, rdfTypes.Site.key];
+            const isEntityFolder = Array.from(this.nodes.values()).some(existing =>
+                entityTypes.includes(existing.type) && existing.name === node.basename
+            );
+            if (isEntityFolder) {
+                return;
+            }
+        }
+
+        const new_node = this.buildNodeFromJson(node, parent, level);
         if (!new_node) {
             const existingId = this.proxies_map.get(node.remote_id);
             const existingNode = this.nodes.get(existingId);


### PR DESCRIPTION
## Summary
- avoid creating folder nodes when their names match existing Sample, Subject, or Site entities
- apply duplicate-folder filter to dataset list viewer as well
- display subject age and weight as combined value and unit

## Testing
- `npm test` *(fails: jest: not found)*
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_68bb6cde1d8c83219be765413ef2510a